### PR TITLE
SD-608: add database layer to store user

### DIFF
--- a/src/integTest/kotlin/com/ampnet/blockchainapiservice/repository/JooqUnsignedVerificationMessageRepositoryIntegTest.kt
+++ b/src/integTest/kotlin/com/ampnet/blockchainapiservice/repository/JooqUnsignedVerificationMessageRepositoryIntegTest.kt
@@ -23,7 +23,7 @@ import java.util.UUID
 @JooqTest
 @Import(JooqUnsignedVerificationMessageRepository::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class JooqUnsignedVerificationMessageRepositoryTest : TestBase() {
+class JooqUnsignedVerificationMessageRepositoryIntegTest : TestBase() {
 
     companion object {
         private val WALLET_ADDRESS = WalletAddress("0")

--- a/src/integTest/kotlin/com/ampnet/blockchainapiservice/repository/JooqUnsignedVerificationMessageRepositoryTest.kt
+++ b/src/integTest/kotlin/com/ampnet/blockchainapiservice/repository/JooqUnsignedVerificationMessageRepositoryTest.kt
@@ -1,0 +1,197 @@
+package com.ampnet.blockchainapiservice.repository
+
+import com.ampnet.blockchainapiservice.TestBase
+import com.ampnet.blockchainapiservice.generated.jooq.tables.records.UnsignedVerificationMessageRecord
+import com.ampnet.blockchainapiservice.model.result.UnsignedVerificationMessage
+import com.ampnet.blockchainapiservice.service.UtcDateTimeProvider
+import com.ampnet.blockchainapiservice.testcontainers.PostgresTestContainer
+import com.ampnet.blockchainapiservice.util.UtcDateTime
+import com.ampnet.blockchainapiservice.util.WalletAddress
+import org.assertj.core.api.Assertions.assertThat
+import org.jooq.DSLContext
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.mockito.kotlin.given
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jooq.JooqTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
+import java.time.Duration
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@JooqTest
+@Import(JooqUnsignedVerificationMessageRepository::class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JooqUnsignedVerificationMessageRepositoryTest : TestBase() {
+
+    companion object {
+        private val WALLET_ADDRESS = WalletAddress("0")
+        private val CREATED_AT = UtcDateTime(OffsetDateTime.parse("2022-01-01T00:00:00Z"))
+        private val VALID_UNTIL = CREATED_AT + Duration.ofDays(1L)
+    }
+
+    @Suppress("unused")
+    private val postgresContainer = PostgresTestContainer()
+
+    @Autowired
+    private lateinit var repository: JooqUnsignedVerificationMessageRepository
+
+    @Autowired
+    private lateinit var dslContext: DSLContext
+
+    @MockBean
+    private lateinit var utcDateTimeProvider: UtcDateTimeProvider
+
+    @Test
+    fun mustCorrectlyFetchUnsignedVerificationMessageById() {
+        val id = UUID.randomUUID()
+
+        suppose("some unsigned verification message exists in database") {
+            dslContext.executeInsert(
+                UnsignedVerificationMessageRecord(
+                    id = id,
+                    walletAddress = WALLET_ADDRESS.rawValue,
+                    createdAt = CREATED_AT.value,
+                    validUntil = VALID_UNTIL.value
+                )
+            )
+        }
+
+        verify("unsigned verification message is correctly fetched by ID") {
+            val result = repository.getById(id)
+
+            assertThat(result).withMessage()
+                .isEqualTo(
+                    UnsignedVerificationMessage(
+                        id = id,
+                        walletAddress = WALLET_ADDRESS,
+                        createdAt = CREATED_AT,
+                        validUntil = VALID_UNTIL
+                    )
+                )
+        }
+    }
+
+    @Test
+    fun mustReturnNullWhenFetchNonExistentUnsignedVerificationMessageById() {
+        verify("null is returned when fetching non-existent unsigned verification message") {
+            val result = repository.getById(UUID.randomUUID())
+
+            assertThat(result).withMessage()
+                .isNull()
+        }
+    }
+
+    @Test
+    fun mustCorrectlyStoreUnsignedVerificationMessage() {
+        val message = suppose("some unsigned verification message is created") {
+            createMessage()
+        }
+
+        val storedMessage = suppose("unsigned verification message is stored in database") {
+            repository.store(message)
+        }
+
+        verify("storing unsigned verification message returns correct result") {
+            assertThat(storedMessage).withMessage()
+                .isEqualTo(message)
+        }
+
+        verify("unsigned verification message was stored in database") {
+            val result = repository.getById(message.id)
+
+            assertThat(result).withMessage()
+                .isEqualTo(message)
+        }
+    }
+
+    @Test
+    fun mustCorrectlyDeleteUnsignedVerificationMessageById() {
+        val id = UUID.randomUUID()
+
+        suppose("some unsigned verification message exists in database") {
+            dslContext.executeInsert(
+                UnsignedVerificationMessageRecord(
+                    id = id,
+                    walletAddress = WALLET_ADDRESS.rawValue,
+                    createdAt = CREATED_AT.value,
+                    validUntil = VALID_UNTIL.value
+                )
+            )
+        }
+
+        val isDeleted = suppose("unsigned verification message is deleted by ID") {
+            repository.deleteById(id)
+        }
+
+        verify("unsigned verification message was deleted from database") {
+            assertThat(isDeleted).withMessage()
+                .isTrue()
+
+            val result = repository.getById(id)
+
+            assertThat(result).withMessage()
+                .isNull()
+        }
+    }
+
+    @Test
+    fun mustCorrectlyDeleteAllExpiredUnsignedVerificationMessages() {
+        val expirationTime = CREATED_AT + Duration.ofHours(1L)
+        val expiredMessages = listOf(
+            createMessage(validUntil = expirationTime),
+            createMessage(validUntil = expirationTime - Duration.ofSeconds(30L)),
+            createMessage(validUntil = expirationTime - Duration.ofMinutes(30L))
+        )
+        val nonExpiredMessages = listOf(
+            createMessage(),
+            createMessage()
+        )
+
+        suppose("some messages are stored in database") {
+            expiredMessages.forEach { repository.store(it) }
+            nonExpiredMessages.forEach { repository.store(it) }
+        }
+
+        suppose("current timestamp is equal to specified expiration time") {
+            given(utcDateTimeProvider.getUtcDateTime())
+                .willReturn(expirationTime)
+        }
+
+        val numDeleted = suppose("expired messages are deleted from database") {
+            repository.deleteAllExpired()
+        }
+
+        verify("correct number of messages was deleted") {
+            assertThat(numDeleted).withMessage()
+                .isEqualTo(expiredMessages.size)
+        }
+
+        verify("expired messages are deleted from database") {
+            expiredMessages.forEach {
+                val result = repository.getById(it.id)
+
+                assertThat(result).withMessage()
+                    .isNull()
+            }
+        }
+
+        verify("non-expired messages are still in database") {
+            nonExpiredMessages.forEach {
+                val result = repository.getById(it.id)
+
+                assertThat(result).withMessage()
+                    .isEqualTo(it)
+            }
+        }
+    }
+
+    private fun createMessage(validUntil: UtcDateTime = VALID_UNTIL): UnsignedVerificationMessage =
+        UnsignedVerificationMessage(
+            id = UUID.randomUUID(),
+            walletAddress = WALLET_ADDRESS,
+            createdAt = CREATED_AT,
+            validUntil = validUntil
+        )
+}

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/blockchain/properties/ChainPropertiesHandler.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/blockchain/properties/ChainPropertiesHandler.kt
@@ -2,8 +2,7 @@ package com.ampnet.blockchainapiservice.blockchain.properties
 
 import com.ampnet.blockchainapiservice.config.ApplicationProperties
 import com.ampnet.blockchainapiservice.config.ChainProperties
-import com.ampnet.blockchainapiservice.exception.ErrorCode
-import com.ampnet.blockchainapiservice.exception.InternalException
+import com.ampnet.blockchainapiservice.exception.UnsupportedChainIdException
 import com.ampnet.blockchainapiservice.util.ChainId
 import org.web3j.protocol.Web3j
 import org.web3j.protocol.http.HttpService
@@ -12,7 +11,6 @@ class ChainPropertiesHandler(private val applicationProperties: ApplicationPrope
 
     private val blockchainPropertiesMap = mutableMapOf<ChainId, ChainPropertiesWithServices>()
 
-    @Throws(InternalException::class)
     fun getBlockchainProperties(chainId: ChainId): ChainPropertiesWithServices {
         return blockchainPropertiesMap.computeIfAbsent(chainId) {
             generateBlockchainProperties(getChain(it))
@@ -45,5 +43,5 @@ class ChainPropertiesHandler(private val applicationProperties: ApplicationPrope
     }
 
     private fun getChain(chainId: ChainId) = Chain.fromId(chainId)
-        ?: throw InternalException(ErrorCode.BLOCKCHAIN_ID, "Blockchain id: $chainId not supported")
+        ?: throw UnsupportedChainIdException(chainId)
 }

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/exception/ErrorCode.kt
@@ -1,5 +1,6 @@
 package com.ampnet.blockchainapiservice.exception
 
 enum class ErrorCode {
-    RESOURCE_NOT_FOUND
+    RESOURCE_NOT_FOUND,
+    UNSUPPORTED_CHAIN_ID
 }

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/exception/Exceptions.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/exception/Exceptions.kt
@@ -1,5 +1,6 @@
 package com.ampnet.blockchainapiservice.exception
 
+import com.ampnet.blockchainapiservice.util.ChainId
 import org.springframework.http.HttpStatus
 
 abstract class ServiceException(
@@ -19,5 +20,15 @@ class ResourceNotFoundException(message: String) : ServiceException(
 ) {
     companion object {
         private const val serialVersionUID: Long = 8937915498141342807L
+    }
+}
+
+class UnsupportedChainIdException(chainId: ChainId) : ServiceException(
+    errorCode = ErrorCode.UNSUPPORTED_CHAIN_ID,
+    httpStatus = HttpStatus.BAD_REQUEST,
+    message = "Blockchain id: $chainId not supported"
+) {
+    companion object {
+        private const val serialVersionUID: Long = -8803854722161717146L
     }
 }

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/model/result/UnsignedVerificationMessage.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/model/result/UnsignedVerificationMessage.kt
@@ -1,20 +1,20 @@
 package com.ampnet.blockchainapiservice.model.result
 
+import com.ampnet.blockchainapiservice.util.UtcDateTime
 import com.ampnet.blockchainapiservice.util.WalletAddress
 import java.time.Duration
-import java.time.OffsetDateTime
 import java.util.UUID
 
 data class UnsignedVerificationMessage(
     val id: UUID,
     val walletAddress: WalletAddress,
-    val createdAt: OffsetDateTime,
-    val validUntil: OffsetDateTime
+    val createdAt: UtcDateTime,
+    val validUntil: UtcDateTime
 ) {
-    constructor(id: UUID, walletAddress: WalletAddress, createdAt: OffsetDateTime, validityDuration: Duration) :
-        this(id, walletAddress, createdAt, createdAt.plus(validityDuration))
+    constructor(id: UUID, walletAddress: WalletAddress, createdAt: UtcDateTime, validityDuration: Duration) :
+        this(id, walletAddress, createdAt, createdAt + validityDuration)
 
-    fun isValid(now: OffsetDateTime): Boolean {
+    fun isValid(now: UtcDateTime): Boolean {
         return now.isBefore(validUntil)
     }
 }

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/model/result/UnsignedVerificationMessage.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/model/result/UnsignedVerificationMessage.kt
@@ -1,0 +1,20 @@
+package com.ampnet.blockchainapiservice.model.result
+
+import com.ampnet.blockchainapiservice.util.WalletAddress
+import java.time.Duration
+import java.time.OffsetDateTime
+import java.util.UUID
+
+data class UnsignedVerificationMessage(
+    val id: UUID,
+    val walletAddress: WalletAddress,
+    val createdAt: OffsetDateTime,
+    val validUntil: OffsetDateTime
+) {
+    constructor(id: UUID, walletAddress: WalletAddress, createdAt: OffsetDateTime, validityDuration: Duration) :
+        this(id, walletAddress, createdAt, createdAt.plus(validityDuration))
+
+    fun isValid(now: OffsetDateTime): Boolean {
+        return now.isBefore(validUntil)
+    }
+}

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/repository/JooqUnsignedVerificationMessageRepository.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/repository/JooqUnsignedVerificationMessageRepository.kt
@@ -2,7 +2,8 @@ package com.ampnet.blockchainapiservice.repository
 
 import com.ampnet.blockchainapiservice.generated.jooq.tables.records.UnsignedVerificationMessageRecord
 import com.ampnet.blockchainapiservice.model.result.UnsignedVerificationMessage
-import com.ampnet.blockchainapiservice.service.OffsetDateTimeProvider
+import com.ampnet.blockchainapiservice.service.UtcDateTimeProvider
+import com.ampnet.blockchainapiservice.util.UtcDateTime
 import com.ampnet.blockchainapiservice.util.WalletAddress
 import mu.KLogging
 import org.jooq.DSLContext
@@ -13,7 +14,7 @@ import com.ampnet.blockchainapiservice.generated.jooq.tables.UnsignedVerificatio
 @Repository
 class JooqUnsignedVerificationMessageRepository(
     private val dslContext: DSLContext,
-    private val offsetDateTimeProvider: OffsetDateTimeProvider
+    private val utcDateTimeProvider: UtcDateTimeProvider
 ) : UnsignedVerificationMessageRepository {
 
     companion object : KLogging()
@@ -39,10 +40,10 @@ class JooqUnsignedVerificationMessageRepository(
     }
 
     override fun deleteAllExpired(): Int {
-        val now = offsetDateTimeProvider.getOffsetDateTime()
+        val now = utcDateTimeProvider.getUtcDateTime()
         logger.info { "Delete all unsigned verification messages expired at: $now" }
         return dslContext.deleteFrom(UnsignedVerificationMessageTable.UNSIGNED_VERIFICATION_MESSAGE)
-            .where(UnsignedVerificationMessageTable.UNSIGNED_VERIFICATION_MESSAGE.VALID_UNTIL.le(now))
+            .where(UnsignedVerificationMessageTable.UNSIGNED_VERIFICATION_MESSAGE.VALID_UNTIL.le(now.value))
             .execute()
     }
 
@@ -50,15 +51,15 @@ class JooqUnsignedVerificationMessageRepository(
         UnsignedVerificationMessageRecord(
             id = id,
             walletAddress = walletAddress.rawValue,
-            createdAt = createdAt,
-            validUntil = validUntil
+            createdAt = createdAt.value,
+            validUntil = validUntil.value
         )
 
     private fun UnsignedVerificationMessageRecord.toModel(): UnsignedVerificationMessage =
         UnsignedVerificationMessage(
             id = id!!,
             walletAddress = WalletAddress(walletAddress!!),
-            createdAt = createdAt!!,
-            validUntil = validUntil!!
+            createdAt = UtcDateTime(createdAt!!),
+            validUntil = UtcDateTime(validUntil!!)
         )
 }

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/repository/JooqUnsignedVerificationMessageRepository.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/repository/JooqUnsignedVerificationMessageRepository.kt
@@ -1,0 +1,64 @@
+package com.ampnet.blockchainapiservice.repository
+
+import com.ampnet.blockchainapiservice.generated.jooq.tables.records.UnsignedVerificationMessageRecord
+import com.ampnet.blockchainapiservice.model.result.UnsignedVerificationMessage
+import com.ampnet.blockchainapiservice.service.OffsetDateTimeProvider
+import com.ampnet.blockchainapiservice.util.WalletAddress
+import mu.KLogging
+import org.jooq.DSLContext
+import org.springframework.stereotype.Repository
+import java.util.UUID
+import com.ampnet.blockchainapiservice.generated.jooq.tables.UnsignedVerificationMessage as UnsignedVerificationMessageTable
+
+@Repository
+class JooqUnsignedVerificationMessageRepository(
+    private val dslContext: DSLContext,
+    private val offsetDateTimeProvider: OffsetDateTimeProvider
+) : UnsignedVerificationMessageRepository {
+
+    companion object : KLogging()
+
+    override fun getById(id: UUID): UnsignedVerificationMessage? {
+        logger.debug { "Get unsigned verification message by ID: $id" }
+        return dslContext.selectFrom(UnsignedVerificationMessageTable.UNSIGNED_VERIFICATION_MESSAGE)
+            .where(UnsignedVerificationMessageTable.UNSIGNED_VERIFICATION_MESSAGE.ID.eq(id))
+            .fetchOne { it.toModel() }
+    }
+
+    override fun store(message: UnsignedVerificationMessage): UnsignedVerificationMessage {
+        logger.info { "Storing unsigned verification message: $message" }
+        dslContext.executeInsert(message.toRecord())
+        return message
+    }
+
+    override fun deleteById(id: UUID): Boolean {
+        logger.info { "Delete unsigned verification message by ID: $id" }
+        return dslContext.deleteFrom(UnsignedVerificationMessageTable.UNSIGNED_VERIFICATION_MESSAGE)
+            .where(UnsignedVerificationMessageTable.UNSIGNED_VERIFICATION_MESSAGE.ID.eq(id))
+            .execute() > 0
+    }
+
+    override fun deleteAllExpired(): Int {
+        val now = offsetDateTimeProvider.getOffsetDateTime()
+        logger.info { "Delete all unsigned verification messages expired at: $now" }
+        return dslContext.deleteFrom(UnsignedVerificationMessageTable.UNSIGNED_VERIFICATION_MESSAGE)
+            .where(UnsignedVerificationMessageTable.UNSIGNED_VERIFICATION_MESSAGE.VALID_UNTIL.le(now))
+            .execute()
+    }
+
+    private fun UnsignedVerificationMessage.toRecord(): UnsignedVerificationMessageRecord =
+        UnsignedVerificationMessageRecord(
+            id = id,
+            walletAddress = walletAddress.rawValue,
+            createdAt = createdAt,
+            validUntil = validUntil
+        )
+
+    private fun UnsignedVerificationMessageRecord.toModel(): UnsignedVerificationMessage =
+        UnsignedVerificationMessage(
+            id = id!!,
+            walletAddress = WalletAddress(walletAddress!!),
+            createdAt = createdAt!!,
+            validUntil = validUntil!!
+        )
+}

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/repository/UnsignedVerificationMessageRepository.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/repository/UnsignedVerificationMessageRepository.kt
@@ -1,0 +1,11 @@
+package com.ampnet.blockchainapiservice.repository
+
+import com.ampnet.blockchainapiservice.model.result.UnsignedVerificationMessage
+import java.util.UUID
+
+interface UnsignedVerificationMessageRepository {
+    fun getById(id: UUID): UnsignedVerificationMessage?
+    fun store(message: UnsignedVerificationMessage): UnsignedVerificationMessage
+    fun deleteById(id: UUID): Boolean
+    fun deleteAllExpired(): Int
+}

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/service/Providers.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/service/Providers.kt
@@ -1,7 +1,7 @@
 package com.ampnet.blockchainapiservice.service
 
 import org.springframework.stereotype.Service
-import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.util.UUID
 
 interface UuidProvider {
@@ -13,11 +13,11 @@ class RandomUuidProvider : UuidProvider {
     override fun getUuid(): UUID = UUID.randomUUID()
 }
 
-interface LocalDateTimeProvider {
-    fun getLocalDateTime(): LocalDateTime
+interface OffsetDateTimeProvider {
+    fun getOffsetDateTime(): OffsetDateTime
 }
 
 @Service
-class CurrentLocalDateTimeProvider : LocalDateTimeProvider {
-    override fun getLocalDateTime(): LocalDateTime = LocalDateTime.now()
+class CurrentOffsetDateTimeProvider : OffsetDateTimeProvider {
+    override fun getOffsetDateTime(): OffsetDateTime = OffsetDateTime.now()
 }

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/service/Providers.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/service/Providers.kt
@@ -1,5 +1,6 @@
 package com.ampnet.blockchainapiservice.service
 
+import com.ampnet.blockchainapiservice.util.UtcDateTime
 import org.springframework.stereotype.Service
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -13,11 +14,11 @@ class RandomUuidProvider : UuidProvider {
     override fun getUuid(): UUID = UUID.randomUUID()
 }
 
-interface OffsetDateTimeProvider {
-    fun getOffsetDateTime(): OffsetDateTime
+interface UtcDateTimeProvider {
+    fun getUtcDateTime(): UtcDateTime
 }
 
 @Service
-class CurrentOffsetDateTimeProvider : OffsetDateTimeProvider {
-    override fun getOffsetDateTime(): OffsetDateTime = OffsetDateTime.now()
+class CurrentUtcDateTimeProvider : UtcDateTimeProvider {
+    override fun getUtcDateTime(): UtcDateTime = UtcDateTime(OffsetDateTime.now())
 }

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/util/ValueClasses.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/util/ValueClasses.kt
@@ -3,6 +3,22 @@ package com.ampnet.blockchainapiservice.util
 import org.web3j.abi.datatypes.Address
 import org.web3j.abi.datatypes.Uint
 import java.math.BigInteger
+import java.time.Duration
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+@JvmInline
+value class UtcDateTime private constructor(val value: OffsetDateTime) {
+    companion object {
+        private val ZONE_OFFSET = ZoneOffset.UTC
+        operator fun invoke(value: OffsetDateTime) = UtcDateTime(value.withOffsetSameInstant(ZONE_OFFSET))
+    }
+
+    operator fun plus(duration: Duration): UtcDateTime = UtcDateTime(value + duration)
+    operator fun minus(duration: Duration): UtcDateTime = UtcDateTime(value - duration)
+
+    fun isBefore(other: UtcDateTime): Boolean = value.isBefore(other.value)
+}
 
 @JvmInline
 value class WalletAddress private constructor(val value: Address) {

--- a/src/main/resources/db/migration/V1__dummy.sql
+++ b/src/main/resources/db/migration/V1__dummy.sql
@@ -1,3 +1,0 @@
-CREATE TABLE blockchain_api_service.dummy (
-    id UUID PRIMARY KEY
-);

--- a/src/main/resources/db/migration/V1__unsigned_verification_message_table.sql
+++ b/src/main/resources/db/migration/V1__unsigned_verification_message_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE blockchain_api_service.unsigned_verification_message (
+    id             UUID                     PRIMARY KEY,
+    wallet_address VARCHAR                  NOT NULL,
+    created_at     TIMESTAMP WITH TIME ZONE NOT NULL,
+    valid_until    TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+CREATE INDEX unsigned_verification_message_valid_until
+    ON blockchain_api_service.unsigned_verification_message(valid_until);

--- a/src/test/kotlin/com/ampnet/blockchainapiservice/blockchain/ChainPropertiesHandlerTest.kt
+++ b/src/test/kotlin/com/ampnet/blockchainapiservice/blockchain/ChainPropertiesHandlerTest.kt
@@ -5,7 +5,7 @@ import com.ampnet.blockchainapiservice.blockchain.properties.Chain
 import com.ampnet.blockchainapiservice.blockchain.properties.ChainPropertiesHandler
 import com.ampnet.blockchainapiservice.config.ApplicationProperties
 import com.ampnet.blockchainapiservice.exception.ErrorCode
-import com.ampnet.blockchainapiservice.exception.InternalException
+import com.ampnet.blockchainapiservice.exception.UnsupportedChainIdException
 import com.ampnet.blockchainapiservice.util.ChainId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -32,10 +32,10 @@ class ChainPropertiesHandlerTest : TestBase() {
         }
 
         verify("InternalException is thrown") {
-            val exception = assertThrows<InternalException>(message) {
+            val exception = assertThrows<UnsupportedChainIdException>(message) {
                 chainPropertiesHandler.getBlockchainProperties(ChainId(-1))
             }
-            assertThat(exception.errorCode).withMessage().isEqualTo(ErrorCode.BLOCKCHAIN_ID)
+            assertThat(exception.errorCode).withMessage().isEqualTo(ErrorCode.UNSUPPORTED_CHAIN_ID)
         }
     }
 


### PR DESCRIPTION
Adds database layer to store unsigned verification messages. Subtask 1/3 of [SD-596](sd-596-provide-api-to-verify-wallet-address). Test coverage will be increased in follow-up tasks, this one targets only the repository layer.