### PR TITLE
SD-609: add service layer to generate user messages to sign

### DIFF
--- a/src/main/kotlin/com/ampnet/blockchainapiservice/config/ApplicationProperties.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/config/ApplicationProperties.kt
@@ -26,6 +26,7 @@ class ChainProperties {
     var startBlockNumber: BigInteger? = null
 }
 
+@Suppress("MagicNumber")
 class VerificationProperties {
     var unsignedMessageValidity: Duration = Duration.ofMinutes(15L)
 }

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/config/ApplicationProperties.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/config/ApplicationProperties.kt
@@ -3,6 +3,7 @@ package com.ampnet.blockchainapiservice.config
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Configuration
 import java.math.BigInteger
+import java.time.Duration
 
 @Configuration
 @ConfigurationProperties(prefix = "blockchain-api-service")
@@ -13,6 +14,7 @@ class ApplicationProperties {
     val chainMatic = ChainProperties()
     val chainMumbai = ChainProperties()
     val chainHardhatTestnet = ChainProperties()
+    val verification = VerificationProperties()
     var infuraId: String = ""
 }
 
@@ -22,4 +24,8 @@ class JwtProperties {
 
 class ChainProperties {
     var startBlockNumber: BigInteger? = null
+}
+
+class VerificationProperties {
+    var unsignedMessageValidity: Duration = Duration.ofMinutes(15L)
 }

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/service/VerificationService.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/service/VerificationService.kt
@@ -1,0 +1,8 @@
+package com.ampnet.blockchainapiservice.service
+
+import com.ampnet.blockchainapiservice.model.result.UnsignedVerificationMessage
+import com.ampnet.blockchainapiservice.util.WalletAddress
+
+interface VerificationService {
+    fun createUnsignedVerificationMessage(walletAddress: WalletAddress): UnsignedVerificationMessage
+}

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/service/VerificationServiceImpl.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/service/VerificationServiceImpl.kt
@@ -1,0 +1,32 @@
+package com.ampnet.blockchainapiservice.service
+
+import com.ampnet.blockchainapiservice.config.ApplicationProperties
+import com.ampnet.blockchainapiservice.model.result.UnsignedVerificationMessage
+import com.ampnet.blockchainapiservice.repository.UnsignedVerificationMessageRepository
+import com.ampnet.blockchainapiservice.util.WalletAddress
+import mu.KLogging
+import org.springframework.stereotype.Service
+
+@Service
+class VerificationServiceImpl(
+    private val applicationProperties: ApplicationProperties,
+    private val unsignedVerificationMessageRepository: UnsignedVerificationMessageRepository,
+    private val uuidProvider: UuidProvider,
+    private val utcDateTimeProvider: UtcDateTimeProvider
+) : VerificationService {
+
+    companion object : KLogging()
+
+    override fun createUnsignedVerificationMessage(walletAddress: WalletAddress): UnsignedVerificationMessage {
+        logger.info { "Creating unsigned verification message for wallet address: $walletAddress" }
+
+        val message = UnsignedVerificationMessage(
+            id = uuidProvider.getUuid(),
+            walletAddress = walletAddress,
+            createdAt = utcDateTimeProvider.getUtcDateTime(),
+            validityDuration = applicationProperties.verification.unsignedMessageValidity
+        )
+
+        return unsignedVerificationMessageRepository.store(message)
+    }
+}

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/service/VerificationServiceImpl.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/service/VerificationServiceImpl.kt
@@ -9,10 +9,10 @@ import org.springframework.stereotype.Service
 
 @Service
 class VerificationServiceImpl(
-    private val applicationProperties: ApplicationProperties,
     private val unsignedVerificationMessageRepository: UnsignedVerificationMessageRepository,
     private val uuidProvider: UuidProvider,
-    private val utcDateTimeProvider: UtcDateTimeProvider
+    private val utcDateTimeProvider: UtcDateTimeProvider,
+    private val applicationProperties: ApplicationProperties
 ) : VerificationService {
 
     companion object : KLogging()

--- a/src/test/kotlin/com/ampnet/blockchainapiservice/service/VerificationServiceTest.kt
+++ b/src/test/kotlin/com/ampnet/blockchainapiservice/service/VerificationServiceTest.kt
@@ -37,7 +37,6 @@ class VerificationServiceTest : TestBase() {
                 .willReturn(message)
         }
 
-
         val uuidProvider = mock<UuidProvider>()
 
         suppose("some UUID is returned") {

--- a/src/test/kotlin/com/ampnet/blockchainapiservice/service/VerificationServiceTest.kt
+++ b/src/test/kotlin/com/ampnet/blockchainapiservice/service/VerificationServiceTest.kt
@@ -1,0 +1,68 @@
+package com.ampnet.blockchainapiservice.service
+
+import com.ampnet.blockchainapiservice.TestBase
+import com.ampnet.blockchainapiservice.config.ApplicationProperties
+import com.ampnet.blockchainapiservice.model.result.UnsignedVerificationMessage
+import com.ampnet.blockchainapiservice.repository.UnsignedVerificationMessageRepository
+import com.ampnet.blockchainapiservice.util.UtcDateTime
+import com.ampnet.blockchainapiservice.util.WalletAddress
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
+import java.time.Duration
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class VerificationServiceTest : TestBase() {
+
+    @Test
+    fun mustCreateUnsignedVerificationMessageWithCorrectWalletAddressAndDuration() {
+        val uuid = UUID.randomUUID()
+        val walletAddress = WalletAddress("123")
+        val now = UtcDateTime(OffsetDateTime.parse("2022-01-01T00:00:00Z"))
+        val validityDuration = Duration.ofDays(1L)
+
+        val message = UnsignedVerificationMessage(
+            id = uuid,
+            walletAddress = walletAddress,
+            createdAt = now,
+            validUntil = now + validityDuration
+        )
+
+        val repository = mock<UnsignedVerificationMessageRepository>()
+
+        suppose("unsigned verification message will be stored into database") {
+            given(repository.store(message))
+                .willReturn(message)
+        }
+
+
+        val uuidProvider = mock<UuidProvider>()
+
+        suppose("some UUID is returned") {
+            given(uuidProvider.getUuid())
+                .willReturn(uuid)
+        }
+
+        val utcDateTimeProvider = mock<UtcDateTimeProvider>()
+
+        suppose("some timestamp is returned") {
+            given(utcDateTimeProvider.getUtcDateTime())
+                .willReturn(now)
+        }
+
+        val applicationProperties = suppose("validity duration is set in application properties") {
+            ApplicationProperties().apply { verification.unsignedMessageValidity = validityDuration }
+        }
+
+        val service = VerificationServiceImpl(repository, uuidProvider, utcDateTimeProvider, applicationProperties)
+
+        verify("unsigned verification message is correctly created") {
+            val result = service.createUnsignedVerificationMessage(walletAddress)
+
+            assertThat(result).withMessage()
+                .isEqualTo(message)
+        }
+    }
+}


### PR DESCRIPTION
Service layer for generating verification messages. Subtask 2/3 of [SD-596](sd-596-provide-api-to-verify-wallet-address).

Before reviewing this PR, review #1 first.