### PR TITLE
SD-611: add database layer to store signed

### DIFF
--- a/src/integTest/kotlin/com/ampnet/blockchainapiservice/repository/JooqSignedVerificationMessageRepositoryIntegTest.kt
+++ b/src/integTest/kotlin/com/ampnet/blockchainapiservice/repository/JooqSignedVerificationMessageRepositoryIntegTest.kt
@@ -28,7 +28,8 @@ class JooqSignedVerificationMessageRepositoryIntegTest : TestBase() {
     companion object {
         private val WALLET_ADDRESS = WalletAddress("0")
         private val CREATED_AT = UtcDateTime(OffsetDateTime.parse("2022-01-01T00:00:00Z"))
-        private val VALID_UNTIL = CREATED_AT + Duration.ofDays(1L)
+        private val VERIFIED_AT = CREATED_AT + Duration.ofMinutes(1L)
+        private val VALID_UNTIL = VERIFIED_AT + Duration.ofDays(1L)
         private const val SIGNATURE = "test_signature"
     }
 
@@ -55,6 +56,7 @@ class JooqSignedVerificationMessageRepositoryIntegTest : TestBase() {
                     walletAddress = WALLET_ADDRESS.rawValue,
                     signature = SIGNATURE,
                     createdAt = CREATED_AT.value,
+                    verifiedAt = VERIFIED_AT.value,
                     validUntil = VALID_UNTIL.value
                 )
             )
@@ -70,6 +72,7 @@ class JooqSignedVerificationMessageRepositoryIntegTest : TestBase() {
                         walletAddress = WALLET_ADDRESS,
                         signature = SIGNATURE,
                         createdAt = CREATED_AT,
+                        verifiedAt = VERIFIED_AT,
                         validUntil = VALID_UNTIL
                     )
                 )
@@ -120,6 +123,7 @@ class JooqSignedVerificationMessageRepositoryIntegTest : TestBase() {
                     walletAddress = WALLET_ADDRESS.rawValue,
                     signature = SIGNATURE,
                     createdAt = CREATED_AT.value,
+                    verifiedAt = VERIFIED_AT.value,
                     validUntil = VALID_UNTIL.value
                 )
             )
@@ -197,6 +201,7 @@ class JooqSignedVerificationMessageRepositoryIntegTest : TestBase() {
             walletAddress = WALLET_ADDRESS,
             signature = SIGNATURE,
             createdAt = CREATED_AT,
+            verifiedAt = VERIFIED_AT,
             validUntil = validUntil
         )
 }

--- a/src/integTest/kotlin/com/ampnet/blockchainapiservice/repository/JooqSignedVerificationMessageRepositoryIntegTest.kt
+++ b/src/integTest/kotlin/com/ampnet/blockchainapiservice/repository/JooqSignedVerificationMessageRepositoryIntegTest.kt
@@ -1,0 +1,202 @@
+package com.ampnet.blockchainapiservice.repository
+
+import com.ampnet.blockchainapiservice.TestBase
+import com.ampnet.blockchainapiservice.generated.jooq.tables.records.SignedVerificationMessageRecord
+import com.ampnet.blockchainapiservice.model.result.SignedVerificationMessage
+import com.ampnet.blockchainapiservice.service.UtcDateTimeProvider
+import com.ampnet.blockchainapiservice.testcontainers.PostgresTestContainer
+import com.ampnet.blockchainapiservice.util.UtcDateTime
+import com.ampnet.blockchainapiservice.util.WalletAddress
+import org.assertj.core.api.Assertions.assertThat
+import org.jooq.DSLContext
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.mockito.kotlin.given
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jooq.JooqTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
+import java.time.Duration
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@JooqTest
+@Import(JooqSignedVerificationMessageRepository::class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JooqSignedVerificationMessageRepositoryIntegTest : TestBase() {
+
+    companion object {
+        private val WALLET_ADDRESS = WalletAddress("0")
+        private val CREATED_AT = UtcDateTime(OffsetDateTime.parse("2022-01-01T00:00:00Z"))
+        private val VALID_UNTIL = CREATED_AT + Duration.ofDays(1L)
+        private const val SIGNATURE = "test_signature"
+    }
+
+    @Suppress("unused")
+    private val postgresContainer = PostgresTestContainer()
+
+    @Autowired
+    private lateinit var repository: JooqSignedVerificationMessageRepository
+
+    @Autowired
+    private lateinit var dslContext: DSLContext
+
+    @MockBean
+    private lateinit var utcDateTimeProvider: UtcDateTimeProvider
+
+    @Test
+    fun mustCorrectlyFetchSignedVerificationMessageById() {
+        val id = UUID.randomUUID()
+
+        suppose("some signed verification message exists in database") {
+            dslContext.executeInsert(
+                SignedVerificationMessageRecord(
+                    id = id,
+                    walletAddress = WALLET_ADDRESS.rawValue,
+                    signature = SIGNATURE,
+                    createdAt = CREATED_AT.value,
+                    validUntil = VALID_UNTIL.value
+                )
+            )
+        }
+
+        verify("signed verification message is correctly fetched by ID") {
+            val result = repository.getById(id)
+
+            assertThat(result).withMessage()
+                .isEqualTo(
+                    SignedVerificationMessage(
+                        id = id,
+                        walletAddress = WALLET_ADDRESS,
+                        signature = SIGNATURE,
+                        createdAt = CREATED_AT,
+                        validUntil = VALID_UNTIL
+                    )
+                )
+        }
+    }
+
+    @Test
+    fun mustReturnNullWhenFetchNonExistentSignedVerificationMessageById() {
+        verify("null is returned when fetching non-existent signed verification message") {
+            val result = repository.getById(UUID.randomUUID())
+
+            assertThat(result).withMessage()
+                .isNull()
+        }
+    }
+
+    @Test
+    fun mustCorrectlyStoreSignedVerificationMessage() {
+        val message = suppose("some signed verification message is created") {
+            createMessage()
+        }
+
+        val storedMessage = suppose("signed verification message is stored in database") {
+            repository.store(message)
+        }
+
+        verify("storing signed verification message returns correct result") {
+            assertThat(storedMessage).withMessage()
+                .isEqualTo(message)
+        }
+
+        verify("signed verification message was stored in database") {
+            val result = repository.getById(message.id)
+
+            assertThat(result).withMessage()
+                .isEqualTo(message)
+        }
+    }
+
+    @Test
+    fun mustCorrectlyDeleteSignedVerificationMessageById() {
+        val id = UUID.randomUUID()
+
+        suppose("some signed verification message exists in database") {
+            dslContext.executeInsert(
+                SignedVerificationMessageRecord(
+                    id = id,
+                    walletAddress = WALLET_ADDRESS.rawValue,
+                    signature = SIGNATURE,
+                    createdAt = CREATED_AT.value,
+                    validUntil = VALID_UNTIL.value
+                )
+            )
+        }
+
+        val isDeleted = suppose("signed verification message is deleted by ID") {
+            repository.deleteById(id)
+        }
+
+        verify("signed verification message was deleted from database") {
+            assertThat(isDeleted).withMessage()
+                .isTrue()
+
+            val result = repository.getById(id)
+
+            assertThat(result).withMessage()
+                .isNull()
+        }
+    }
+
+    @Test
+    fun mustCorrectlyDeleteAllExpiredSignedVerificationMessages() {
+        val expirationTime = CREATED_AT + Duration.ofHours(1L)
+        val expiredMessages = listOf(
+            createMessage(validUntil = expirationTime),
+            createMessage(validUntil = expirationTime - Duration.ofSeconds(30L)),
+            createMessage(validUntil = expirationTime - Duration.ofMinutes(30L))
+        )
+        val nonExpiredMessages = listOf(
+            createMessage(),
+            createMessage()
+        )
+
+        suppose("some messages are stored in database") {
+            expiredMessages.forEach { repository.store(it) }
+            nonExpiredMessages.forEach { repository.store(it) }
+        }
+
+        suppose("current timestamp is equal to specified expiration time") {
+            given(utcDateTimeProvider.getUtcDateTime())
+                .willReturn(expirationTime)
+        }
+
+        val numDeleted = suppose("expired messages are deleted from database") {
+            repository.deleteAllExpired()
+        }
+
+        verify("correct number of messages was deleted") {
+            assertThat(numDeleted).withMessage()
+                .isEqualTo(expiredMessages.size)
+        }
+
+        verify("expired messages are deleted from database") {
+            expiredMessages.forEach {
+                val result = repository.getById(it.id)
+
+                assertThat(result).withMessage()
+                    .isNull()
+            }
+        }
+
+        verify("non-expired messages are still in database") {
+            nonExpiredMessages.forEach {
+                val result = repository.getById(it.id)
+
+                assertThat(result).withMessage()
+                    .isEqualTo(it)
+            }
+        }
+    }
+
+    private fun createMessage(validUntil: UtcDateTime = VALID_UNTIL): SignedVerificationMessage =
+        SignedVerificationMessage(
+            id = UUID.randomUUID(),
+            walletAddress = WALLET_ADDRESS,
+            signature = SIGNATURE,
+            createdAt = CREATED_AT,
+            validUntil = validUntil
+        )
+}

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/model/result/SignedVerificationMessage.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/model/result/SignedVerificationMessage.kt
@@ -1,0 +1,17 @@
+package com.ampnet.blockchainapiservice.model.result
+
+import com.ampnet.blockchainapiservice.util.UtcDateTime
+import com.ampnet.blockchainapiservice.util.WalletAddress
+import java.util.UUID
+
+data class SignedVerificationMessage(
+    val id: UUID,
+    val walletAddress: WalletAddress,
+    val signature: String,
+    val createdAt: UtcDateTime,
+    val validUntil: UtcDateTime
+) {
+    fun isValid(now: UtcDateTime): Boolean {
+        return now.isBefore(validUntil)
+    }
+}

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/model/result/SignedVerificationMessage.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/model/result/SignedVerificationMessage.kt
@@ -9,6 +9,7 @@ data class SignedVerificationMessage(
     val walletAddress: WalletAddress,
     val signature: String,
     val createdAt: UtcDateTime,
+    val verifiedAt: UtcDateTime,
     val validUntil: UtcDateTime
 ) {
     fun isValid(now: UtcDateTime): Boolean {

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/model/result/UnsignedVerificationMessage.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/model/result/UnsignedVerificationMessage.kt
@@ -18,6 +18,16 @@ data class UnsignedVerificationMessage(
         return now.isBefore(validUntil)
     }
 
+    // TODO add validation here in SD-612
+    fun withSignature(signature: String, now: UtcDateTime, validityDuration: Duration): SignedVerificationMessage =
+        SignedVerificationMessage(
+            id = id,
+            walletAddress = walletAddress,
+            signature = signature,
+            createdAt = now,
+            validUntil = now + validityDuration
+        )
+
     fun toStringMessage(): String =
         "By signing this message, I verify that I'm the owner of wallet address ${walletAddress.rawValue}." +
             " Message ID: $id, timestamp: ${createdAt.value.toInstant().toEpochMilli()}"

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/model/result/UnsignedVerificationMessage.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/model/result/UnsignedVerificationMessage.kt
@@ -18,7 +18,6 @@ data class UnsignedVerificationMessage(
         return now.isBefore(validUntil)
     }
 
-    // TODO add validation here in SD-612
     fun withSignature(signature: String, now: UtcDateTime, validityDuration: Duration): SignedVerificationMessage =
         SignedVerificationMessage(
             id = id,

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/model/result/UnsignedVerificationMessage.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/model/result/UnsignedVerificationMessage.kt
@@ -18,7 +18,7 @@ data class UnsignedVerificationMessage(
         return now.isBefore(validUntil)
     }
 
-    fun withSignature(signature: String, now: UtcDateTime, validityDuration: Duration): SignedVerificationMessage =
+    fun toSignedMessage(signature: String, now: UtcDateTime, validityDuration: Duration): SignedVerificationMessage =
         SignedVerificationMessage(
             id = id,
             walletAddress = walletAddress,

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/model/result/UnsignedVerificationMessage.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/model/result/UnsignedVerificationMessage.kt
@@ -23,7 +23,8 @@ data class UnsignedVerificationMessage(
             id = id,
             walletAddress = walletAddress,
             signature = signature,
-            createdAt = now,
+            createdAt = createdAt,
+            verifiedAt = now,
             validUntil = now + validityDuration
         )
 

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/repository/JooqSignedVerificationMessageRepository.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/repository/JooqSignedVerificationMessageRepository.kt
@@ -53,6 +53,7 @@ class JooqSignedVerificationMessageRepository(
             walletAddress = walletAddress.rawValue,
             signature = signature,
             createdAt = createdAt.value,
+            verifiedAt = verifiedAt.value,
             validUntil = validUntil.value
         )
 
@@ -62,6 +63,7 @@ class JooqSignedVerificationMessageRepository(
             walletAddress = WalletAddress(walletAddress!!),
             signature = signature!!,
             createdAt = UtcDateTime(createdAt!!),
+            verifiedAt = UtcDateTime(verifiedAt!!),
             validUntil = UtcDateTime(validUntil!!)
         )
 }

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/repository/JooqSignedVerificationMessageRepository.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/repository/JooqSignedVerificationMessageRepository.kt
@@ -1,0 +1,67 @@
+package com.ampnet.blockchainapiservice.repository
+
+import com.ampnet.blockchainapiservice.generated.jooq.tables.records.SignedVerificationMessageRecord
+import com.ampnet.blockchainapiservice.model.result.SignedVerificationMessage
+import com.ampnet.blockchainapiservice.service.UtcDateTimeProvider
+import com.ampnet.blockchainapiservice.util.UtcDateTime
+import com.ampnet.blockchainapiservice.util.WalletAddress
+import mu.KLogging
+import org.jooq.DSLContext
+import org.springframework.stereotype.Repository
+import java.util.UUID
+import com.ampnet.blockchainapiservice.generated.jooq.tables.SignedVerificationMessage as SignedVerificationMessageTable
+
+@Repository
+class JooqSignedVerificationMessageRepository(
+    private val dslContext: DSLContext,
+    private val utcDateTimeProvider: UtcDateTimeProvider
+) : SignedVerificationMessageRepository {
+
+    companion object : KLogging()
+
+    override fun getById(id: UUID): SignedVerificationMessage? {
+        logger.debug { "Get signed verification message by ID: $id" }
+        return dslContext.selectFrom(SignedVerificationMessageTable.SIGNED_VERIFICATION_MESSAGE)
+            .where(SignedVerificationMessageTable.SIGNED_VERIFICATION_MESSAGE.ID.eq(id))
+            .fetchOne { it.toModel() }
+    }
+
+    override fun store(message: SignedVerificationMessage): SignedVerificationMessage {
+        logger.info { "Storing signed verification message: $message" }
+        dslContext.executeInsert(message.toRecord())
+        return message
+    }
+
+    override fun deleteById(id: UUID): Boolean {
+        logger.info { "Delete signed verification message by ID: $id" }
+        return dslContext.deleteFrom(SignedVerificationMessageTable.SIGNED_VERIFICATION_MESSAGE)
+            .where(SignedVerificationMessageTable.SIGNED_VERIFICATION_MESSAGE.ID.eq(id))
+            .execute() > 0
+    }
+
+    override fun deleteAllExpired(): Int {
+        val now = utcDateTimeProvider.getUtcDateTime()
+        logger.info { "Delete all signed verification messages expired at: $now" }
+        return dslContext.deleteFrom(SignedVerificationMessageTable.SIGNED_VERIFICATION_MESSAGE)
+            .where(SignedVerificationMessageTable.SIGNED_VERIFICATION_MESSAGE.VALID_UNTIL.le(now.value))
+            .execute()
+    }
+
+    private fun SignedVerificationMessage.toRecord(): SignedVerificationMessageRecord =
+        SignedVerificationMessageRecord(
+            id = id,
+            walletAddress = walletAddress.rawValue,
+            signature = signature,
+            createdAt = createdAt.value,
+            validUntil = validUntil.value
+        )
+
+    private fun SignedVerificationMessageRecord.toModel(): SignedVerificationMessage =
+        SignedVerificationMessage(
+            id = id!!,
+            walletAddress = WalletAddress(walletAddress!!),
+            signature = signature!!,
+            createdAt = UtcDateTime(createdAt!!),
+            validUntil = UtcDateTime(validUntil!!)
+        )
+}

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/repository/SignedVerificationMessageRepository.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/repository/SignedVerificationMessageRepository.kt
@@ -1,0 +1,11 @@
+package com.ampnet.blockchainapiservice.repository
+
+import com.ampnet.blockchainapiservice.model.result.SignedVerificationMessage
+import java.util.UUID
+
+interface SignedVerificationMessageRepository {
+    fun getById(id: UUID): SignedVerificationMessage?
+    fun store(message: SignedVerificationMessage): SignedVerificationMessage
+    fun deleteById(id: UUID): Boolean
+    fun deleteAllExpired(): Int
+}

--- a/src/main/resources/db/migration/V2__signed_verification_message_table.sql
+++ b/src/main/resources/db/migration/V2__signed_verification_message_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE blockchain_api_service.signed_verification_message (
+    id             UUID                     PRIMARY KEY,
+    wallet_address VARCHAR                  NOT NULL,
+    signature      VARCHAR                  NOT NULL,
+    created_at     TIMESTAMP WITH TIME ZONE NOT NULL,
+    valid_until    TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+CREATE INDEX signed_verification_message_valid_until
+    ON blockchain_api_service.signed_verification_message(valid_until);

--- a/src/main/resources/db/migration/V2__signed_verification_message_table.sql
+++ b/src/main/resources/db/migration/V2__signed_verification_message_table.sql
@@ -3,6 +3,7 @@ CREATE TABLE blockchain_api_service.signed_verification_message (
     wallet_address VARCHAR                  NOT NULL,
     signature      VARCHAR                  NOT NULL,
     created_at     TIMESTAMP WITH TIME ZONE NOT NULL,
+    verified_at    TIMESTAMP WITH TIME ZONE NOT NULL,
     valid_until    TIMESTAMP WITH TIME ZONE NOT NULL
 );
 


### PR DESCRIPTION
Adds database layer to store signed verification messages. Subtask 1/3 of [SD-597](https://linear.app/ampnet/issue/SD-597/provide-api-endpoint-where-user-can-send-signed-message).