### PR TITLE
SD-612: add service layer to verify signed user

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,6 +103,7 @@ dependencies {
     jooqGenerator(Configurations.Database.driverDependency)
 
     implementation("org.web3j:core:${Versions.Dependencies.web3j}")
+    implementation("com.github.komputing:kethereum:${Versions.Dependencies.kethereum}")
     implementation("com.squareup.okhttp3:okhttp:${Versions.Dependencies.okHttp}")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.Dependencies.kotlinCoroutines}")
     implementation("io.github.microutils:kotlin-logging-jvm:${Versions.Dependencies.kotlinLogging}")

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -32,6 +32,7 @@ object Versions {
 
     object Dependencies {
         const val web3j = "4.8.9"
+        const val kethereum = "0.85.7"
         const val okHttp = "4.9.3"
         const val kotlinCoroutines = "1.6.0"
         const val kotlinLogging = "2.1.21"

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/config/ApplicationProperties.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/config/ApplicationProperties.kt
@@ -29,4 +29,5 @@ class ChainProperties {
 @Suppress("MagicNumber")
 class VerificationProperties {
     var unsignedMessageValidity: Duration = Duration.ofMinutes(15L)
+    var signedMessageValidity: Duration = Duration.ofMinutes(5L)
 }

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/exception/ErrorCode.kt
@@ -2,5 +2,7 @@ package com.ampnet.blockchainapiservice.exception
 
 enum class ErrorCode {
     RESOURCE_NOT_FOUND,
-    UNSUPPORTED_CHAIN_ID
+    UNSUPPORTED_CHAIN_ID,
+    VALIDATION_MESSAGE_EXPIRED,
+    BAD_SIGNATURE
 }

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/exception/Exceptions.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/exception/Exceptions.kt
@@ -2,6 +2,7 @@ package com.ampnet.blockchainapiservice.exception
 
 import com.ampnet.blockchainapiservice.util.ChainId
 import org.springframework.http.HttpStatus
+import java.util.UUID
 
 abstract class ServiceException(
     val errorCode: ErrorCode,
@@ -30,5 +31,25 @@ class UnsupportedChainIdException(chainId: ChainId) : ServiceException(
 ) {
     companion object {
         private const val serialVersionUID: Long = -8803854722161717146L
+    }
+}
+
+class ExpiredValidationMessageException(messageId: UUID) : ServiceException(
+    errorCode = ErrorCode.VALIDATION_MESSAGE_EXPIRED,
+    httpStatus = HttpStatus.PRECONDITION_FAILED,
+    message = "Validation message with ID: $messageId has expired"
+) {
+    companion object {
+        private const val serialVersionUID: Long = -8531346107518192369L
+    }
+}
+
+class BadSignatureException(message: String) : ServiceException(
+    errorCode = ErrorCode.BAD_SIGNATURE,
+    httpStatus = HttpStatus.BAD_REQUEST,
+    message = message
+) {
+    companion object {
+        private const val serialVersionUID: Long = 1135423205237947970L
     }
 }

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/model/result/SignedVerificationMessage.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/model/result/SignedVerificationMessage.kt
@@ -12,7 +12,7 @@ data class SignedVerificationMessage(
     val verifiedAt: UtcDateTime,
     val validUntil: UtcDateTime
 ) {
-    fun isValid(now: UtcDateTime): Boolean {
-        return now.isBefore(validUntil)
+    fun isExpired(now: UtcDateTime): Boolean {
+        return now.isAfter(validUntil)
     }
 }

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/model/result/UnsignedVerificationMessage.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/model/result/UnsignedVerificationMessage.kt
@@ -14,8 +14,8 @@ data class UnsignedVerificationMessage(
     constructor(id: UUID, walletAddress: WalletAddress, createdAt: UtcDateTime, validityDuration: Duration) :
         this(id, walletAddress, createdAt, createdAt + validityDuration)
 
-    fun isValid(now: UtcDateTime): Boolean {
-        return now.isBefore(validUntil)
+    fun isExpired(now: UtcDateTime): Boolean {
+        return now.isAfter(validUntil)
     }
 
     fun toSignedMessage(signature: String, now: UtcDateTime, validityDuration: Duration): SignedVerificationMessage =

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/service/VerificationService.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/service/VerificationService.kt
@@ -1,8 +1,11 @@
 package com.ampnet.blockchainapiservice.service
 
+import com.ampnet.blockchainapiservice.model.result.SignedVerificationMessage
 import com.ampnet.blockchainapiservice.model.result.UnsignedVerificationMessage
 import com.ampnet.blockchainapiservice.util.WalletAddress
+import java.util.UUID
 
 interface VerificationService {
     fun createUnsignedVerificationMessage(walletAddress: WalletAddress): UnsignedVerificationMessage
+    fun verifyMessageSignature(messageId: UUID, signature: String): SignedVerificationMessage
 }

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/service/VerificationService.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/service/VerificationService.kt
@@ -7,5 +7,5 @@ import java.util.UUID
 
 interface VerificationService {
     fun createUnsignedVerificationMessage(walletAddress: WalletAddress): UnsignedVerificationMessage
-    fun verifyMessageSignature(messageId: UUID, signature: String): SignedVerificationMessage
+    fun verifyAndStoreMessageSignature(messageId: UUID, signature: String): SignedVerificationMessage
 }

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/service/VerificationServiceImpl.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/service/VerificationServiceImpl.kt
@@ -1,21 +1,43 @@
 package com.ampnet.blockchainapiservice.service
 
 import com.ampnet.blockchainapiservice.config.ApplicationProperties
+import com.ampnet.blockchainapiservice.exception.BadSignatureException
+import com.ampnet.blockchainapiservice.exception.ExpiredValidationMessageException
+import com.ampnet.blockchainapiservice.exception.ResourceNotFoundException
+import com.ampnet.blockchainapiservice.model.result.SignedVerificationMessage
 import com.ampnet.blockchainapiservice.model.result.UnsignedVerificationMessage
+import com.ampnet.blockchainapiservice.repository.SignedVerificationMessageRepository
 import com.ampnet.blockchainapiservice.repository.UnsignedVerificationMessageRepository
 import com.ampnet.blockchainapiservice.util.WalletAddress
 import mu.KLogging
+import org.kethereum.crypto.signedMessageToKey
+import org.kethereum.crypto.toAddress
+import org.kethereum.model.SignatureData
 import org.springframework.stereotype.Service
+import java.math.BigInteger
+import java.util.UUID
 
 @Service
 class VerificationServiceImpl(
     private val unsignedVerificationMessageRepository: UnsignedVerificationMessageRepository,
+    private val signedVerificationMessageRepository: SignedVerificationMessageRepository,
     private val uuidProvider: UuidProvider,
     private val utcDateTimeProvider: UtcDateTimeProvider,
     private val applicationProperties: ApplicationProperties
 ) : VerificationService {
 
-    companion object : KLogging()
+    companion object : KLogging() {
+        private const val EIP_191_MAGIC_BYTE = 0x19.toByte()
+        private const val SIGNATURE_LENGTH = 132
+        private const val R_START = 2
+        private const val R_END = 2
+        private const val S_START = 66
+        private const val S_END = 130
+        private const val V_START = 130
+        private const val V_END = 132
+        private const val HEX_RADIX = 16
+        private val V_OFFSET = BigInteger.valueOf(27L)
+    }
 
     override fun createUnsignedVerificationMessage(walletAddress: WalletAddress): UnsignedVerificationMessage {
         logger.info { "Creating unsigned verification message for wallet address: $walletAddress" }
@@ -28,5 +50,70 @@ class VerificationServiceImpl(
         )
 
         return unsignedVerificationMessageRepository.store(message)
+    }
+
+    override fun verifyMessageSignature(messageId: UUID, signature: String): SignedVerificationMessage {
+        logger.info { "Verifying message signature, messageId: $messageId, signature: $signature" }
+
+        val unsignedMessage = unsignedVerificationMessageRepository.getById(messageId)
+            ?: throw ResourceNotFoundException("Message not found for ID: $messageId")
+
+        val now = utcDateTimeProvider.getUtcDateTime()
+
+        if (!unsignedMessage.isValid(now)) {
+            throw ExpiredValidationMessageException(messageId)
+        }
+
+        val signatureData = getSignatureData(signature)
+        val eip919 = generateEip191Message(unsignedMessage.toStringMessage().toByteArray())
+        val publicKey = signedMessageToKey(eip919, signatureData)
+        val signatureAddress = WalletAddress(publicKey.toAddress().toString())
+
+        if (signatureAddress != unsignedMessage.walletAddress) {
+            throw BadSignatureException(
+                "Public address of provided signature does not match expected signature address"
+            )
+        }
+
+        val deletionResult = unsignedVerificationMessageRepository.deleteById(messageId)
+        logger.debug { "Unsigned message with ID: $messageId was deleted: $deletionResult" }
+
+        return signedVerificationMessageRepository.store(
+            unsignedMessage.toSignedMessage(
+                signature = signature,
+                now = now,
+                validityDuration = applicationProperties.verification.signedMessageValidity
+            )
+        )
+    }
+
+    private fun generateEip191Message(message: ByteArray): ByteArray =
+        byteArrayOf(EIP_191_MAGIC_BYTE) + ("Ethereum Signed Message:\n" + message.size).toByteArray() + message
+
+    private fun BigInteger.withVOffset(): BigInteger =
+        if (this == BigInteger.ZERO || this == BigInteger.ONE) {
+            this + V_OFFSET
+        } else {
+            this
+        }
+
+    private fun getSignatureData(signature: String): SignatureData {
+        if (signature.length != SIGNATURE_LENGTH) {
+            throw BadSignatureException("Signature: $signature is of wrong length")
+        }
+
+        val r = signature.substring(R_START, R_END)
+        val s = signature.substring(S_START, S_END)
+        val v = signature.substring(V_START, V_END)
+
+        try {
+            return SignatureData(
+                r = BigInteger(r, HEX_RADIX),
+                s = BigInteger(s, HEX_RADIX),
+                v = BigInteger(v, HEX_RADIX).withVOffset()
+            )
+        } catch (ex: NumberFormatException) {
+            throw BadSignatureException("Signature: $signature is not a valid hex value")
+        }
     }
 }

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/service/VerificationServiceImpl.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/service/VerificationServiceImpl.kt
@@ -30,7 +30,7 @@ class VerificationServiceImpl(
         private const val EIP_191_MAGIC_BYTE = 0x19.toByte()
         private const val SIGNATURE_LENGTH = 132
         private const val R_START = 2
-        private const val R_END = 2
+        private const val R_END = 66
         private const val S_START = 66
         private const val S_END = 130
         private const val V_START = 130

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/service/VerificationServiceImpl.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/service/VerificationServiceImpl.kt
@@ -60,7 +60,7 @@ class VerificationServiceImpl(
 
         val now = utcDateTimeProvider.getUtcDateTime()
 
-        if (!unsignedMessage.isValid(now)) {
+        if (unsignedMessage.isExpired(now)) {
             throw ExpiredValidationMessageException(messageId)
         }
 

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/service/VerificationServiceImpl.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/service/VerificationServiceImpl.kt
@@ -52,7 +52,7 @@ class VerificationServiceImpl(
         return unsignedVerificationMessageRepository.store(message)
     }
 
-    override fun verifyMessageSignature(messageId: UUID, signature: String): SignedVerificationMessage {
+    override fun verifyAndStoreMessageSignature(messageId: UUID, signature: String): SignedVerificationMessage {
         logger.info { "Verifying message signature, messageId: $messageId, signature: $signature" }
 
         val unsignedMessage = unsignedVerificationMessageRepository.getById(messageId)

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/util/ValueClasses.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/util/ValueClasses.kt
@@ -17,7 +17,7 @@ value class UtcDateTime private constructor(val value: OffsetDateTime) {
     operator fun plus(duration: Duration): UtcDateTime = UtcDateTime(value + duration)
     operator fun minus(duration: Duration): UtcDateTime = UtcDateTime(value - duration)
 
-    fun isBefore(other: UtcDateTime): Boolean = value.isBefore(other.value)
+    fun isAfter(other: UtcDateTime): Boolean = value.isAfter(other.value)
 }
 
 @JvmInline

--- a/src/test/kotlin/com/ampnet/blockchainapiservice/service/VerificationServiceTest.kt
+++ b/src/test/kotlin/com/ampnet/blockchainapiservice/service/VerificationServiceTest.kt
@@ -3,6 +3,7 @@ package com.ampnet.blockchainapiservice.service
 import com.ampnet.blockchainapiservice.TestBase
 import com.ampnet.blockchainapiservice.config.ApplicationProperties
 import com.ampnet.blockchainapiservice.model.result.UnsignedVerificationMessage
+import com.ampnet.blockchainapiservice.repository.SignedVerificationMessageRepository
 import com.ampnet.blockchainapiservice.repository.UnsignedVerificationMessageRepository
 import com.ampnet.blockchainapiservice.util.UtcDateTime
 import com.ampnet.blockchainapiservice.util.WalletAddress
@@ -30,10 +31,10 @@ class VerificationServiceTest : TestBase() {
             validUntil = now + validityDuration
         )
 
-        val repository = mock<UnsignedVerificationMessageRepository>()
+        val unsignedMessageRepository = mock<UnsignedVerificationMessageRepository>()
 
         suppose("unsigned verification message will be stored into database") {
-            given(repository.store(message))
+            given(unsignedMessageRepository.store(message))
                 .willReturn(message)
         }
 
@@ -55,7 +56,14 @@ class VerificationServiceTest : TestBase() {
             ApplicationProperties().apply { verification.unsignedMessageValidity = validityDuration }
         }
 
-        val service = VerificationServiceImpl(repository, uuidProvider, utcDateTimeProvider, applicationProperties)
+        val signedMessageRepository = mock<SignedVerificationMessageRepository>()
+        val service = VerificationServiceImpl(
+            unsignedMessageRepository,
+            signedMessageRepository,
+            uuidProvider,
+            utcDateTimeProvider,
+            applicationProperties
+        )
 
         verify("unsigned verification message is correctly created") {
             val result = service.createUnsignedVerificationMessage(walletAddress)

--- a/src/test/kotlin/com/ampnet/blockchainapiservice/service/VerificationServiceTest.kt
+++ b/src/test/kotlin/com/ampnet/blockchainapiservice/service/VerificationServiceTest.kt
@@ -119,7 +119,7 @@ class VerificationServiceTest : TestBase() {
 
         verify("ResourceNotFoundException is thrown") {
             assertThrows<ResourceNotFoundException>(message) {
-                service.verifyMessageSignature(SIGNED_MESSAGE.id, SIGNED_MESSAGE.signature)
+                service.verifyAndStoreMessageSignature(SIGNED_MESSAGE.id, SIGNED_MESSAGE.signature)
             }
         }
     }
@@ -159,7 +159,7 @@ class VerificationServiceTest : TestBase() {
 
         verify("ExpiredValidationMessageException is thrown") {
             assertThrows<ExpiredValidationMessageException>(message) {
-                service.verifyMessageSignature(SIGNED_MESSAGE.id, SIGNED_MESSAGE.signature)
+                service.verifyAndStoreMessageSignature(SIGNED_MESSAGE.id, SIGNED_MESSAGE.signature)
             }
         }
     }
@@ -199,7 +199,7 @@ class VerificationServiceTest : TestBase() {
 
         verify("BadSignatureException is thrown") {
             assertThrows<BadSignatureException>(message) {
-                service.verifyMessageSignature(SIGNED_MESSAGE.id, "too short signature")
+                service.verifyAndStoreMessageSignature(SIGNED_MESSAGE.id, "too short signature")
             }
         }
     }
@@ -239,7 +239,10 @@ class VerificationServiceTest : TestBase() {
 
         verify("BadSignatureException is thrown") {
             assertThrows<BadSignatureException>(message) {
-                service.verifyMessageSignature(SIGNED_MESSAGE.id, SIGNED_MESSAGE.signature.replace(".".toRegex(), "x"))
+                service.verifyAndStoreMessageSignature(
+                    SIGNED_MESSAGE.id,
+                    SIGNED_MESSAGE.signature.replace(".".toRegex(), "x")
+                )
             }
         }
     }
@@ -279,7 +282,7 @@ class VerificationServiceTest : TestBase() {
 
         verify("BadSignatureException is thrown") {
             assertThrows<BadSignatureException>(message) {
-                service.verifyMessageSignature(SIGNED_MESSAGE.id, OTHER_SIGNATURE)
+                service.verifyAndStoreMessageSignature(SIGNED_MESSAGE.id, OTHER_SIGNATURE)
             }
         }
     }
@@ -331,7 +334,7 @@ class VerificationServiceTest : TestBase() {
         )
 
         verify("valid message is correctly verified") {
-            val result = service.verifyMessageSignature(SIGNED_MESSAGE.id, SIGNED_MESSAGE.signature)
+            val result = service.verifyAndStoreMessageSignature(SIGNED_MESSAGE.id, SIGNED_MESSAGE.signature)
 
             assertThat(result).withMessage()
                 .isEqualTo(SIGNED_MESSAGE)

--- a/src/test/kotlin/com/ampnet/blockchainapiservice/service/VerificationServiceTest.kt
+++ b/src/test/kotlin/com/ampnet/blockchainapiservice/service/VerificationServiceTest.kt
@@ -2,6 +2,10 @@ package com.ampnet.blockchainapiservice.service
 
 import com.ampnet.blockchainapiservice.TestBase
 import com.ampnet.blockchainapiservice.config.ApplicationProperties
+import com.ampnet.blockchainapiservice.exception.BadSignatureException
+import com.ampnet.blockchainapiservice.exception.ExpiredValidationMessageException
+import com.ampnet.blockchainapiservice.exception.ResourceNotFoundException
+import com.ampnet.blockchainapiservice.model.result.SignedVerificationMessage
 import com.ampnet.blockchainapiservice.model.result.UnsignedVerificationMessage
 import com.ampnet.blockchainapiservice.repository.SignedVerificationMessageRepository
 import com.ampnet.blockchainapiservice.repository.UnsignedVerificationMessageRepository
@@ -9,6 +13,8 @@ import com.ampnet.blockchainapiservice.util.UtcDateTime
 import com.ampnet.blockchainapiservice.util.WalletAddress
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
 import java.time.Duration
@@ -16,6 +22,23 @@ import java.time.OffsetDateTime
 import java.util.UUID
 
 class VerificationServiceTest : TestBase() {
+
+    companion object {
+        // this message was signed using Metamask
+        private val SIGNED_MESSAGE = SignedVerificationMessage(
+            id = UUID.fromString("7d86b0ac-a9a6-40fc-ac6d-2a29ca687f73"),
+            walletAddress = WalletAddress("0x865f603F42ca1231e5B5F90e15663b0FE19F0b21"),
+            signature = "0x2601a91eed301102ca423ffc36e43b4dc096bb556ecfb83f508047b34ab7236f4cd1eaaae98ee8eac9cde62988" +
+                "f062891f3c84e241d320cf338bdfc17a51bc131b",
+            createdAt = UtcDateTime(OffsetDateTime.parse("2022-01-01T00:00:00Z")),
+            verifiedAt = UtcDateTime(OffsetDateTime.parse("2022-01-01T01:00:00Z")),
+            validUntil = UtcDateTime(OffsetDateTime.parse("2022-01-01T02:00:00Z"))
+        )
+
+        // also signed using Metamask, but using another address
+        private const val OTHER_SIGNATURE = "0x4f6e4a316147dcc797a89cf6163643a5f0315dbed5fbf8976f2af1ada260468c53411d" +
+            "b1d501550f171463322dbcf8427c9b34ff40513bec90d46b75b910b7c71b"
+    }
 
     @Test
     fun mustCreateUnsignedVerificationMessageWithCorrectWalletAddressAndDuration() {
@@ -70,6 +93,248 @@ class VerificationServiceTest : TestBase() {
 
             assertThat(result).withMessage()
                 .isEqualTo(message)
+        }
+    }
+
+    @Test
+    fun mustThrowResourceNotFoundExceptionWhenUnsignedMessageDoesNotExist() {
+        val unsignedMessageRepository = mock<UnsignedVerificationMessageRepository>()
+
+        suppose("unsigned verification message repository will return null") {
+            given(unsignedMessageRepository.getById(any()))
+                .willReturn(null)
+        }
+
+        val signedMessageRepository = mock<SignedVerificationMessageRepository>()
+        val uuidProvider = mock<UuidProvider>()
+        val utcDateTimeProvider = mock<UtcDateTimeProvider>()
+        val applicationProperties = ApplicationProperties()
+        val service = VerificationServiceImpl(
+            unsignedMessageRepository,
+            signedMessageRepository,
+            uuidProvider,
+            utcDateTimeProvider,
+            applicationProperties
+        )
+
+        verify("ResourceNotFoundException is thrown") {
+            assertThrows<ResourceNotFoundException>(message) {
+                service.verifyMessageSignature(SIGNED_MESSAGE.id, SIGNED_MESSAGE.signature)
+            }
+        }
+    }
+
+    @Test
+    fun mustThrowExpiredValidationMessageExceptionWhenUnsignedMessageHasExpired() {
+        val unsignedMessageRepository = mock<UnsignedVerificationMessageRepository>()
+        val unsignedMessage = UnsignedVerificationMessage(
+            id = SIGNED_MESSAGE.id,
+            walletAddress = SIGNED_MESSAGE.walletAddress,
+            createdAt = SIGNED_MESSAGE.createdAt,
+            validUntil = SIGNED_MESSAGE.validUntil
+        )
+
+        suppose("unsigned verification message repository will return unsigned verification message") {
+            given(unsignedMessageRepository.getById(SIGNED_MESSAGE.id))
+                .willReturn(unsignedMessage)
+        }
+
+        val utcDateTimeProvider = mock<UtcDateTimeProvider>()
+
+        suppose("current time is after unsigned message validity time") {
+            given(utcDateTimeProvider.getUtcDateTime())
+                .willReturn(SIGNED_MESSAGE.validUntil + Duration.ofMinutes(1L))
+        }
+
+        val signedMessageRepository = mock<SignedVerificationMessageRepository>()
+        val uuidProvider = mock<UuidProvider>()
+        val applicationProperties = ApplicationProperties()
+        val service = VerificationServiceImpl(
+            unsignedMessageRepository,
+            signedMessageRepository,
+            uuidProvider,
+            utcDateTimeProvider,
+            applicationProperties
+        )
+
+        verify("ExpiredValidationMessageException is thrown") {
+            assertThrows<ExpiredValidationMessageException>(message) {
+                service.verifyMessageSignature(SIGNED_MESSAGE.id, SIGNED_MESSAGE.signature)
+            }
+        }
+    }
+
+    @Test
+    fun mustThrowBadSignatureExceptionWhenMessageSignatureLengthIsInvalid() {
+        val unsignedMessageRepository = mock<UnsignedVerificationMessageRepository>()
+        val unsignedMessage = UnsignedVerificationMessage(
+            id = SIGNED_MESSAGE.id,
+            walletAddress = SIGNED_MESSAGE.walletAddress,
+            createdAt = SIGNED_MESSAGE.createdAt,
+            validUntil = SIGNED_MESSAGE.validUntil
+        )
+
+        suppose("unsigned verification message repository will return unsigned verification message") {
+            given(unsignedMessageRepository.getById(SIGNED_MESSAGE.id))
+                .willReturn(unsignedMessage)
+        }
+
+        val utcDateTimeProvider = mock<UtcDateTimeProvider>()
+
+        suppose("current time is before unsigned message validity time") {
+            given(utcDateTimeProvider.getUtcDateTime())
+                .willReturn(SIGNED_MESSAGE.verifiedAt)
+        }
+
+        val signedMessageRepository = mock<SignedVerificationMessageRepository>()
+        val uuidProvider = mock<UuidProvider>()
+        val applicationProperties = ApplicationProperties()
+        val service = VerificationServiceImpl(
+            unsignedMessageRepository,
+            signedMessageRepository,
+            uuidProvider,
+            utcDateTimeProvider,
+            applicationProperties
+        )
+
+        verify("BadSignatureException is thrown") {
+            assertThrows<BadSignatureException>(message) {
+                service.verifyMessageSignature(SIGNED_MESSAGE.id, "too short signature")
+            }
+        }
+    }
+
+    @Test
+    fun mustThrowBadSignatureExceptionWhenMessageSignatureHasCorrectLengthAndInvalidFormat() {
+        val unsignedMessageRepository = mock<UnsignedVerificationMessageRepository>()
+        val unsignedMessage = UnsignedVerificationMessage(
+            id = SIGNED_MESSAGE.id,
+            walletAddress = SIGNED_MESSAGE.walletAddress,
+            createdAt = SIGNED_MESSAGE.createdAt,
+            validUntil = SIGNED_MESSAGE.validUntil
+        )
+
+        suppose("unsigned verification message repository will return unsigned verification message") {
+            given(unsignedMessageRepository.getById(SIGNED_MESSAGE.id))
+                .willReturn(unsignedMessage)
+        }
+
+        val utcDateTimeProvider = mock<UtcDateTimeProvider>()
+
+        suppose("current time is before unsigned message validity time") {
+            given(utcDateTimeProvider.getUtcDateTime())
+                .willReturn(SIGNED_MESSAGE.verifiedAt)
+        }
+
+        val signedMessageRepository = mock<SignedVerificationMessageRepository>()
+        val uuidProvider = mock<UuidProvider>()
+        val applicationProperties = ApplicationProperties()
+        val service = VerificationServiceImpl(
+            unsignedMessageRepository,
+            signedMessageRepository,
+            uuidProvider,
+            utcDateTimeProvider,
+            applicationProperties
+        )
+
+        verify("BadSignatureException is thrown") {
+            assertThrows<BadSignatureException>(message) {
+                service.verifyMessageSignature(SIGNED_MESSAGE.id, SIGNED_MESSAGE.signature.replace(".".toRegex(), "x"))
+            }
+        }
+    }
+
+    @Test
+    fun mustThrowBadSignatureExceptionWhenMessageSignatureIsInValid() {
+        val unsignedMessageRepository = mock<UnsignedVerificationMessageRepository>()
+        val unsignedMessage = UnsignedVerificationMessage(
+            id = SIGNED_MESSAGE.id,
+            walletAddress = SIGNED_MESSAGE.walletAddress,
+            createdAt = SIGNED_MESSAGE.createdAt,
+            validUntil = SIGNED_MESSAGE.validUntil
+        )
+
+        suppose("unsigned verification message repository will return unsigned verification message") {
+            given(unsignedMessageRepository.getById(SIGNED_MESSAGE.id))
+                .willReturn(unsignedMessage)
+        }
+
+        val utcDateTimeProvider = mock<UtcDateTimeProvider>()
+
+        suppose("current time is before unsigned message validity time") {
+            given(utcDateTimeProvider.getUtcDateTime())
+                .willReturn(SIGNED_MESSAGE.verifiedAt)
+        }
+
+        val signedMessageRepository = mock<SignedVerificationMessageRepository>()
+        val uuidProvider = mock<UuidProvider>()
+        val applicationProperties = ApplicationProperties()
+        val service = VerificationServiceImpl(
+            unsignedMessageRepository,
+            signedMessageRepository,
+            uuidProvider,
+            utcDateTimeProvider,
+            applicationProperties
+        )
+
+        verify("BadSignatureException is thrown") {
+            assertThrows<BadSignatureException>(message) {
+                service.verifyMessageSignature(SIGNED_MESSAGE.id, OTHER_SIGNATURE)
+            }
+        }
+    }
+
+    @Test
+    fun mustCorrectlyVerifyValidMessageSignature() {
+        val unsignedMessageRepository = mock<UnsignedVerificationMessageRepository>()
+        val unsignedMessage = UnsignedVerificationMessage(
+            id = SIGNED_MESSAGE.id,
+            walletAddress = SIGNED_MESSAGE.walletAddress,
+            createdAt = SIGNED_MESSAGE.createdAt,
+            validUntil = SIGNED_MESSAGE.validUntil
+        )
+
+        suppose("unsigned verification message repository will return unsigned verification message") {
+            given(unsignedMessageRepository.getById(SIGNED_MESSAGE.id))
+                .willReturn(unsignedMessage)
+        }
+
+        val utcDateTimeProvider = mock<UtcDateTimeProvider>()
+
+        suppose("current time is before unsigned message validity time") {
+            given(utcDateTimeProvider.getUtcDateTime())
+                .willReturn(SIGNED_MESSAGE.verifiedAt)
+        }
+
+        suppose("unsigned verification message will be deleted by ID") {
+            given(unsignedMessageRepository.deleteById(SIGNED_MESSAGE.id))
+                .willReturn(true)
+        }
+
+        val signedMessageRepository = mock<SignedVerificationMessageRepository>()
+
+        suppose("correct signed message is stored in database") {
+            given(signedMessageRepository.store(SIGNED_MESSAGE))
+                .willReturn(SIGNED_MESSAGE)
+        }
+
+        val uuidProvider = mock<UuidProvider>()
+        val applicationProperties = ApplicationProperties().apply {
+            verification.signedMessageValidity = Duration.ofHours(1L)
+        }
+        val service = VerificationServiceImpl(
+            unsignedMessageRepository,
+            signedMessageRepository,
+            uuidProvider,
+            utcDateTimeProvider,
+            applicationProperties
+        )
+
+        verify("valid message is correctly verified") {
+            val result = service.verifyMessageSignature(SIGNED_MESSAGE.id, SIGNED_MESSAGE.signature)
+
+            assertThat(result).withMessage()
+                .isEqualTo(SIGNED_MESSAGE)
         }
     }
 }


### PR DESCRIPTION
Adds service layer to verify correctness of signed messages. Subtask 2/3 of [SD-597](https://linear.app/ampnet/issue/SD-597/provide-api-endpoint-where-user-can-send-signed-message).