### PR TITLE
SD-613: add api layer to allow user to send signed messages

### DIFF
--- a/src/apiTest/kotlin/com/ampnet/blockchainapiservice/controller/VerificationControllerApiTest.kt
+++ b/src/apiTest/kotlin/com/ampnet/blockchainapiservice/controller/VerificationControllerApiTest.kt
@@ -1,16 +1,27 @@
 package com.ampnet.blockchainapiservice.controller
 
 import com.ampnet.blockchainapiservice.ControllerTestBase
+import com.ampnet.blockchainapiservice.TestData
+import com.ampnet.blockchainapiservice.config.ApplicationProperties
+import com.ampnet.blockchainapiservice.exception.ErrorCode
 import com.ampnet.blockchainapiservice.model.response.GenerateVerificationMessageResponse
+import com.ampnet.blockchainapiservice.model.response.VerifySignedMessageResponse
 import com.ampnet.blockchainapiservice.model.result.UnsignedVerificationMessage
+import com.ampnet.blockchainapiservice.repository.SignedVerificationMessageRepository
 import com.ampnet.blockchainapiservice.repository.UnsignedVerificationMessageRepository
+import com.ampnet.blockchainapiservice.service.UtcDateTimeProvider
 import org.assertj.core.api.Assertions.assertThat
 import org.jooq.DSLContext
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.given
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import java.time.Duration
+import com.ampnet.blockchainapiservice.generated.jooq.tables.SignedVerificationMessage as SignedVerificationMessageTable
 import com.ampnet.blockchainapiservice.generated.jooq.tables.UnsignedVerificationMessage as UnsignedVerificationMessageTable
 
 class VerificationControllerApiTest : ControllerTestBase() {
@@ -19,18 +30,30 @@ class VerificationControllerApiTest : ControllerTestBase() {
     private lateinit var unsignedVerificationMessageRepository: UnsignedVerificationMessageRepository
 
     @Autowired
+    private lateinit var signedVerificationMessageRepository: SignedVerificationMessageRepository
+
+    @Autowired
     private lateinit var dslContext: DSLContext
+
+    @MockBean
+    private lateinit var utcDateTimeProvider: UtcDateTimeProvider
 
     @BeforeEach
     fun beforeEach() {
         dslContext.deleteFrom(UnsignedVerificationMessageTable.UNSIGNED_VERIFICATION_MESSAGE).execute()
+        dslContext.deleteFrom(SignedVerificationMessageTable.SIGNED_VERIFICATION_MESSAGE).execute()
     }
 
     @Test
     fun mustCorrectlyGenerateVerificationMessageAndStoreItInDatabase() {
+        suppose("some fixed date-time will be returned") {
+            given(utcDateTimeProvider.getUtcDateTime())
+                .willReturn(TestData.UNSIGNED_MESSAGE.createdAt)
+        }
+
         val generatedMessage = suppose("request to generate verification message is made") {
             val response = mockMvc.perform(
-                MockMvcRequestBuilders.post("/verification/${walletAddress.rawValue}/generate")
+                MockMvcRequestBuilders.post("/verification/generate/${walletAddress.rawValue}")
             )
                 .andExpect(MockMvcResultMatchers.status().isOk)
                 .andReturn()
@@ -60,6 +83,182 @@ class VerificationControllerApiTest : ControllerTestBase() {
                         id = databaseMessage!!.id,
                         message = databaseMessage.toStringMessage(),
                         validUntil = databaseMessage.validUntil.value
+                    )
+                )
+        }
+    }
+
+    @Test
+    fun mustReturn404NotFoundWhenVerifyingNonExistentMessage() {
+        suppose("some fixed date-time will be returned") {
+            given(utcDateTimeProvider.getUtcDateTime())
+                .willReturn(TestData.UNSIGNED_MESSAGE.createdAt)
+        }
+
+        verify("404 is returned for non-existent message") {
+            val response = mockMvc.perform(
+                MockMvcRequestBuilders.post("/verification/signature/${TestData.UNSIGNED_MESSAGE.id}")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\n    \"signature\":\"${TestData.SIGNED_MESSAGE.signature}\"\n}")
+            )
+                .andExpect(MockMvcResultMatchers.status().isNotFound)
+                .andReturn()
+
+            verifyResponseErrorCode(response, ErrorCode.RESOURCE_NOT_FOUND)
+        }
+    }
+
+    @Test
+    fun mustReturn412PreconditionFailedWhenVerifyingExpiredMessage() {
+        suppose("some fixed date-time will be returned") {
+            given(utcDateTimeProvider.getUtcDateTime())
+                .willReturn(TestData.UNSIGNED_MESSAGE.createdAt)
+        }
+
+        suppose("expired unsigned verification message exists in database") {
+            unsignedVerificationMessageRepository.store(
+                TestData.UNSIGNED_MESSAGE.copy(
+                    validUntil = TestData.UNSIGNED_MESSAGE.createdAt - Duration.ofMinutes(1L)
+                )
+            )
+        }
+
+        verify("412 is returned for expired message") {
+            val response = mockMvc.perform(
+                MockMvcRequestBuilders.post("/verification/signature/${TestData.UNSIGNED_MESSAGE.id}")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\n    \"signature\":\"${TestData.SIGNED_MESSAGE.signature}\"\n}")
+            )
+                .andExpect(MockMvcResultMatchers.status().isPreconditionFailed)
+                .andReturn()
+
+            verifyResponseErrorCode(response, ErrorCode.VALIDATION_MESSAGE_EXPIRED)
+        }
+    }
+
+    @Test
+    fun mustReturn400BadRequestWhenVerifyingSignatureWithInvalidLength() {
+        suppose("some fixed date-time will be returned") {
+            given(utcDateTimeProvider.getUtcDateTime())
+                .willReturn(TestData.UNSIGNED_MESSAGE.createdAt)
+        }
+
+        suppose("non-expired unsigned verification message exists in database") {
+            unsignedVerificationMessageRepository.store(TestData.UNSIGNED_MESSAGE)
+        }
+
+        verify("400 is returned for invalid signature length") {
+            val response = mockMvc.perform(
+                MockMvcRequestBuilders.post("/verification/signature/${TestData.UNSIGNED_MESSAGE.id}")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\n    \"signature\":\"${TestData.TOO_SHORT_SIGNATURE}\"\n}")
+            )
+                .andExpect(MockMvcResultMatchers.status().isBadRequest)
+                .andReturn()
+
+            verifyResponseErrorCode(response, ErrorCode.BAD_SIGNATURE)
+        }
+    }
+
+    @Test
+    fun mustReturn400BadRequestWhenVerifyingSignatureWithValidLengthAndInvalidFormat() {
+        suppose("some fixed date-time will be returned") {
+            given(utcDateTimeProvider.getUtcDateTime())
+                .willReturn(TestData.UNSIGNED_MESSAGE.createdAt)
+        }
+
+        suppose("non-expired unsigned verification message exists in database") {
+            unsignedVerificationMessageRepository.store(TestData.UNSIGNED_MESSAGE)
+        }
+
+        verify("400 is returned for invalid signature format") {
+            val response = mockMvc.perform(
+                MockMvcRequestBuilders.post("/verification/signature/${TestData.UNSIGNED_MESSAGE.id}")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\n    \"signature\":\"${TestData.INVALID_SIGNATURE}\"\n}")
+            )
+                .andExpect(MockMvcResultMatchers.status().isBadRequest)
+                .andReturn()
+
+            verifyResponseErrorCode(response, ErrorCode.BAD_SIGNATURE)
+        }
+    }
+
+    @Test
+    fun mustReturn400BadRequestWhenMessageSignatureIsInvalid() {
+        suppose("some fixed date-time will be returned") {
+            given(utcDateTimeProvider.getUtcDateTime())
+                .willReturn(TestData.UNSIGNED_MESSAGE.createdAt)
+        }
+
+        suppose("non-expired unsigned verification message exists in database") {
+            unsignedVerificationMessageRepository.store(TestData.UNSIGNED_MESSAGE)
+        }
+
+        verify("400 is returned for signature mismatch") {
+            val response = mockMvc.perform(
+                MockMvcRequestBuilders.post("/verification/signature/${TestData.UNSIGNED_MESSAGE.id}")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\n    \"signature\":\"${TestData.OTHER_SIGNATURE}\"\n}")
+            )
+                .andExpect(MockMvcResultMatchers.status().isBadRequest)
+                .andReturn()
+
+            verifyResponseErrorCode(response, ErrorCode.BAD_SIGNATURE)
+        }
+    }
+
+    @Test
+    fun mustCorrectlyVerifyValidMessageSignature() {
+        suppose("some fixed date-time will be returned") {
+            given(utcDateTimeProvider.getUtcDateTime())
+                .willReturn(TestData.UNSIGNED_MESSAGE.createdAt)
+        }
+
+        suppose("non-expired unsigned verification message exists in database") {
+            unsignedVerificationMessageRepository.store(TestData.UNSIGNED_MESSAGE)
+        }
+
+        val signedMessage = suppose("request to verify message signature is made") {
+            val response = mockMvc.perform(
+                MockMvcRequestBuilders.post("/verification/signature/${TestData.UNSIGNED_MESSAGE.id}")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\n    \"signature\":\"${TestData.SIGNED_MESSAGE.signature}\"\n}")
+            )
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andReturn()
+
+            objectMapper.readValue(response.response.contentAsString, VerifySignedMessageResponse::class.java)
+        }
+
+        verify("unsigned verification message is deleted from database") {
+            val result = unsignedVerificationMessageRepository.getById(TestData.UNSIGNED_MESSAGE.id)
+
+            assertThat(result).withMessage()
+                .isNull()
+        }
+
+        val signedMessageValidity = ApplicationProperties().verification.signedMessageValidity
+
+        verify("signed verification message is stored in database") {
+            val result = signedVerificationMessageRepository.getById(TestData.SIGNED_MESSAGE.id)
+
+            assertThat(result).withMessage()
+                .isEqualTo(
+                    TestData.SIGNED_MESSAGE.copy(
+                        verifiedAt = utcDateTimeProvider.getUtcDateTime(),
+                        validUntil = utcDateTimeProvider.getUtcDateTime() + signedMessageValidity
+                    )
+                )
+        }
+
+        verify("correct response is returned") {
+            assertThat(signedMessage).withMessage()
+                .isEqualTo(
+                    VerifySignedMessageResponse(
+                        id = TestData.SIGNED_MESSAGE.id,
+                        signature = TestData.SIGNED_MESSAGE.signature,
+                        validUntil = utcDateTimeProvider.getUtcDateTime().value + signedMessageValidity
                     )
                 )
         }

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -24,3 +24,11 @@ is the user wallet address.
 include::{snippets}/VerificationControllerApiTest/mustCorrectlyGenerateVerificationMessageAndStoreItInDatabase/http-request.adoc[]
 .Response
 include::{snippets}/VerificationControllerApiTest/mustCorrectlyGenerateVerificationMessageAndStoreItInDatabase/http-response.adoc[]
+
+=== Verify message signature
+Verifies verification message signature. Path argument is the message ID.
+
+.Request
+include::{snippets}/VerificationControllerApiTest/mustCorrectlyVerifyValidMessageSignature/http-request.adoc[]
+.Response
+include::{snippets}/VerificationControllerApiTest/mustCorrectlyVerifyValidMessageSignature/http-response.adoc[]

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/controller/VerificationController.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/controller/VerificationController.kt
@@ -1,30 +1,50 @@
 package com.ampnet.blockchainapiservice.controller
 
+import com.ampnet.blockchainapiservice.model.request.VerifySignedMessageRequest
 import com.ampnet.blockchainapiservice.model.response.GenerateVerificationMessageResponse
+import com.ampnet.blockchainapiservice.model.response.VerifySignedMessageResponse
 import com.ampnet.blockchainapiservice.service.VerificationService
 import com.ampnet.blockchainapiservice.util.WalletAddress
 import mu.KLogging
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
 
 @RestController
 class VerificationController(private val verificationService: VerificationService) {
 
     companion object : KLogging()
 
-    @PostMapping("/verification/{walletAddress}/generate")
+    @PostMapping("/verification/generate/{walletAddress}")
     fun generateVerificationMessage(
         @PathVariable walletAddress: String
     ): ResponseEntity<GenerateVerificationMessageResponse> {
         logger.info { "Request generation of verification message for wallet address: $walletAddress" }
-        val message = verificationService.createUnsignedVerificationMessage(WalletAddress(walletAddress))
+        val unsignedMessage = verificationService.createUnsignedVerificationMessage(WalletAddress(walletAddress))
         return ResponseEntity.ok(
             GenerateVerificationMessageResponse(
-                id = message.id,
-                message = message.toStringMessage(),
-                validUntil = message.validUntil.value
+                id = unsignedMessage.id,
+                message = unsignedMessage.toStringMessage(),
+                validUntil = unsignedMessage.validUntil.value
+            )
+        )
+    }
+
+    @PostMapping("/verification/signature/{messageId}")
+    fun verifySignedMessage(
+        @PathVariable messageId: UUID,
+        @RequestBody requestBody: VerifySignedMessageRequest
+    ): ResponseEntity<VerifySignedMessageResponse> {
+        logger.info { "Validating signature for messageId: $messageId, signature: ${requestBody.signature}" }
+        val signedMessage = verificationService.verifyMessageSignature(messageId, requestBody.signature)
+        return ResponseEntity.ok(
+            VerifySignedMessageResponse(
+                id = signedMessage.id,
+                signature = signedMessage.signature,
+                validUntil = signedMessage.validUntil
             )
         )
     }

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/controller/VerificationController.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/controller/VerificationController.kt
@@ -39,7 +39,7 @@ class VerificationController(private val verificationService: VerificationServic
         @RequestBody requestBody: VerifySignedMessageRequest
     ): ResponseEntity<VerifySignedMessageResponse> {
         logger.info { "Validating signature for messageId: $messageId, signature: ${requestBody.signature}" }
-        val signedMessage = verificationService.verifyMessageSignature(messageId, requestBody.signature)
+        val signedMessage = verificationService.verifyAndStoreMessageSignature(messageId, requestBody.signature)
         return ResponseEntity.ok(
             VerifySignedMessageResponse(
                 id = signedMessage.id,

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/controller/VerificationController.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/controller/VerificationController.kt
@@ -44,7 +44,7 @@ class VerificationController(private val verificationService: VerificationServic
             VerifySignedMessageResponse(
                 id = signedMessage.id,
                 signature = signedMessage.signature,
-                validUntil = signedMessage.validUntil
+                validUntil = signedMessage.validUntil.value
             )
         )
     }

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/model/request/VerifySignedMessageRequest.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/model/request/VerifySignedMessageRequest.kt
@@ -1,0 +1,3 @@
+package com.ampnet.blockchainapiservice.model.request
+
+data class VerifySignedMessageRequest(val signature: String)

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/model/response/VerifySignedMessageResponse.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/model/response/VerifySignedMessageResponse.kt
@@ -1,10 +1,10 @@
 package com.ampnet.blockchainapiservice.model.response
 
-import com.ampnet.blockchainapiservice.util.UtcDateTime
+import java.time.OffsetDateTime
 import java.util.UUID
 
 data class VerifySignedMessageResponse(
     val id: UUID,
     val signature: String,
-    val validUntil: UtcDateTime
+    val validUntil: OffsetDateTime
 )

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/model/response/VerifySignedMessageResponse.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/model/response/VerifySignedMessageResponse.kt
@@ -1,0 +1,10 @@
+package com.ampnet.blockchainapiservice.model.response
+
+import com.ampnet.blockchainapiservice.util.UtcDateTime
+import java.util.UUID
+
+data class VerifySignedMessageResponse(
+    val id: UUID,
+    val signature: String,
+    val validUntil: UtcDateTime
+)

--- a/src/test/kotlin/com/ampnet/blockchainapiservice/TestData.kt
+++ b/src/test/kotlin/com/ampnet/blockchainapiservice/TestData.kt
@@ -1,0 +1,34 @@
+package com.ampnet.blockchainapiservice
+
+import com.ampnet.blockchainapiservice.model.result.UnsignedVerificationMessage
+import com.ampnet.blockchainapiservice.util.UtcDateTime
+import com.ampnet.blockchainapiservice.util.WalletAddress
+import java.time.Duration
+import java.time.OffsetDateTime
+import java.util.UUID
+
+object TestData {
+
+    val UNSIGNED_MESSAGE = UnsignedVerificationMessage(
+        id = UUID.fromString("7d86b0ac-a9a6-40fc-ac6d-2a29ca687f73"),
+        walletAddress = WalletAddress("0x865f603F42ca1231e5B5F90e15663b0FE19F0b21"),
+        createdAt = UtcDateTime(OffsetDateTime.parse("2022-01-01T00:00:00Z")),
+        validUntil = UtcDateTime(OffsetDateTime.parse("2022-01-01T02:00:00Z"))
+    )
+
+    // this message was signed using Metamask
+    val SIGNED_MESSAGE = UNSIGNED_MESSAGE.toSignedMessage(
+        signature = "0x2601a91eed301102ca423ffc36e43b4dc096bb556ecfb83f508047b34ab7236f4cd1eaaae98ee8eac9cde62988f062" +
+            "891f3c84e241d320cf338bdfc17a51bc131b",
+        now = UtcDateTime(OffsetDateTime.parse("2022-01-01T01:00:00Z")),
+        validityDuration = Duration.ofHours(1L)
+    )
+
+    const val TOO_SHORT_SIGNATURE = "0x"
+    const val INVALID_SIGNATURE = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" +
+        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+    // also signed using Metamask, but using another address
+    const val OTHER_SIGNATURE = "0x4f6e4a316147dcc797a89cf6163643a5f0315dbed5fbf8976f2af1ada260468c53411db1d501550f17" +
+        "1463322dbcf8427c9b34ff40513bec90d46b75b910b7c71b"
+}

--- a/src/test/kotlin/com/ampnet/blockchainapiservice/controller/VerificationControllerTest.kt
+++ b/src/test/kotlin/com/ampnet/blockchainapiservice/controller/VerificationControllerTest.kt
@@ -1,7 +1,10 @@
 package com.ampnet.blockchainapiservice.controller
 
 import com.ampnet.blockchainapiservice.TestBase
+import com.ampnet.blockchainapiservice.model.request.VerifySignedMessageRequest
 import com.ampnet.blockchainapiservice.model.response.GenerateVerificationMessageResponse
+import com.ampnet.blockchainapiservice.model.response.VerifySignedMessageResponse
+import com.ampnet.blockchainapiservice.model.result.SignedVerificationMessage
 import com.ampnet.blockchainapiservice.model.result.UnsignedVerificationMessage
 import com.ampnet.blockchainapiservice.service.VerificationService
 import com.ampnet.blockchainapiservice.util.UtcDateTime
@@ -47,6 +50,45 @@ class VerificationControllerTest : TestBase() {
                             id = message.id,
                             message = message.toStringMessage(),
                             validUntil = message.validUntil.value
+                        )
+                    )
+                )
+        }
+    }
+
+    @Test
+    fun mustReturnVerifiedSignedMessage() {
+        val messageId = UUID.randomUUID()
+        val validUntil = UtcDateTime(OffsetDateTime.parse("2022-01-01T02:00:00Z"))
+        val signature = "test-signature"
+
+        val message = SignedVerificationMessage(
+            id = messageId,
+            walletAddress = WalletAddress("123"),
+            signature = signature,
+            createdAt = UtcDateTime(OffsetDateTime.parse("2022-01-01T00:00:00Z")),
+            verifiedAt = UtcDateTime(OffsetDateTime.parse("2022-01-01T01:00:00Z")),
+            validUntil = validUntil
+        )
+        val service = mock<VerificationService>()
+
+        suppose("service will return some signed verification message") {
+            given(service.verifyMessageSignature(messageId, signature))
+                .willReturn(message)
+        }
+
+        val controller = VerificationController(service)
+
+        verify("controller returns correct response") {
+            val result = controller.verifySignedMessage(messageId, VerifySignedMessageRequest(signature))
+
+            assertThat(result).withMessage()
+                .isEqualTo(
+                    ResponseEntity.ok(
+                        VerifySignedMessageResponse(
+                            id = messageId,
+                            signature = signature,
+                            validUntil = validUntil.value
                         )
                     )
                 )

--- a/src/test/kotlin/com/ampnet/blockchainapiservice/controller/VerificationControllerTest.kt
+++ b/src/test/kotlin/com/ampnet/blockchainapiservice/controller/VerificationControllerTest.kt
@@ -73,7 +73,7 @@ class VerificationControllerTest : TestBase() {
         val service = mock<VerificationService>()
 
         suppose("service will return some signed verification message") {
-            given(service.verifyMessageSignature(messageId, signature))
+            given(service.verifyAndStoreMessageSignature(messageId, signature))
                 .willReturn(message)
         }
 


### PR DESCRIPTION
Adds controller to send and verify signed messages. Subtask 3/3 of [SD-597](https://linear.app/ampnet/issue/SD-597/provide-api-endpoint-where-user-can-send-signed-message).

Before reviewing this PR, review #5 first.