### PR TITLE
SD-617: add API layer to fetch token balance

### DIFF
--- a/src/apiTest/kotlin/com/ampnet/blockchainapiservice/ControllerTestBase.kt
+++ b/src/apiTest/kotlin/com/ampnet/blockchainapiservice/ControllerTestBase.kt
@@ -1,6 +1,7 @@
 package com.ampnet.blockchainapiservice
 
 import com.ampnet.blockchainapiservice.TestBase.Companion.VerifyMessage
+import com.ampnet.blockchainapiservice.blockchain.properties.Chain
 import com.ampnet.blockchainapiservice.exception.ErrorCode
 import com.ampnet.blockchainapiservice.exception.ErrorResponse
 import com.ampnet.blockchainapiservice.testcontainers.HardhatTestContainer
@@ -34,6 +35,7 @@ import org.springframework.web.context.WebApplicationContext
 class ControllerTestBase : TestBase() {
 
     protected final val walletAddress = WalletAddress("0x8f52B0cC50967fc59C6289f8FDB3E356EdeEBD23")
+    protected final val chainId = Chain.HARDHAT_TESTNET.id
 
     @Suppress("unused")
     protected val postgresContainer = PostgresTestContainer()

--- a/src/apiTest/kotlin/com/ampnet/blockchainapiservice/controller/BlockchainInfoControllerApiTest.kt
+++ b/src/apiTest/kotlin/com/ampnet/blockchainapiservice/controller/BlockchainInfoControllerApiTest.kt
@@ -1,0 +1,179 @@
+package com.ampnet.blockchainapiservice.controller
+
+import com.ampnet.blockchainapiservice.ControllerTestBase
+import com.ampnet.blockchainapiservice.TestData
+import com.ampnet.blockchainapiservice.blockchain.SimpleERC20
+import com.ampnet.blockchainapiservice.exception.ErrorCode
+import com.ampnet.blockchainapiservice.model.response.FetchErc20TokenBalanceResponse
+import com.ampnet.blockchainapiservice.repository.SignedVerificationMessageRepository
+import com.ampnet.blockchainapiservice.service.UtcDateTimeProvider
+import com.ampnet.blockchainapiservice.testcontainers.HardhatTestContainer
+import com.ampnet.blockchainapiservice.util.AccountBalance
+import com.ampnet.blockchainapiservice.util.Balance
+import com.ampnet.blockchainapiservice.util.ContractAddress
+import org.assertj.core.api.Assertions.assertThat
+import org.jooq.DSLContext
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.given
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.web3j.protocol.core.RemoteCall
+import org.web3j.tx.gas.DefaultGasProvider
+import java.math.BigInteger
+import java.time.Duration
+import com.ampnet.blockchainapiservice.generated.jooq.tables.SignedVerificationMessage as SignedVerificationMessageTable
+
+class BlockchainInfoControllerApiTest : ControllerTestBase() {
+
+    private val accounts = HardhatTestContainer.accounts
+
+    @Autowired
+    private lateinit var signedVerificationMessageRepository: SignedVerificationMessageRepository
+
+    @Autowired
+    private lateinit var dslContext: DSLContext
+
+    @MockBean
+    private lateinit var utcDateTimeProvider: UtcDateTimeProvider
+
+    @BeforeEach
+    fun beforeEach() {
+        dslContext.deleteFrom(SignedVerificationMessageTable.SIGNED_VERIFICATION_MESSAGE).execute()
+    }
+
+    @Test
+    fun mustCorrectlyFetchErc20Balance() {
+        suppose("some fixed date-time will be returned") {
+            given(utcDateTimeProvider.getUtcDateTime())
+                .willReturn(TestData.SIGNED_MESSAGE.createdAt)
+        }
+
+        val mainAccount = accounts[0]
+        val accountBalance = AccountBalance(TestData.SIGNED_MESSAGE.walletAddress, Balance(BigInteger("10000")))
+
+        val contract = suppose("simple ERC20 contract is deployed") {
+            SimpleERC20.deploy(
+                hardhatContainer.web3j,
+                mainAccount,
+                DefaultGasProvider(),
+                listOf(accountBalance.address.rawValue),
+                listOf(accountBalance.balance.rawValue),
+                mainAccount.address
+            ).sendAndMine()
+        }
+
+        suppose("some signed message is in the database") {
+            signedVerificationMessageRepository.store(TestData.SIGNED_MESSAGE)
+        }
+
+        val blockNumber = hardhatContainer.blockNumber()
+        val contractAddress = ContractAddress(contract.contractAddress)
+
+        val erc20AccountBalance = suppose("request to fetch ERC20 balance is made") {
+            val response = mockMvc.perform(
+                MockMvcRequestBuilders.get(
+                    "/info/${chainId.value}/${TestData.SIGNED_MESSAGE.id}/erc20-balance/${contractAddress.rawValue}"
+                )
+                    .queryParam("blockNumber", blockNumber.value.toString())
+            )
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andReturn()
+
+            objectMapper.readValue(response.response.contentAsString, FetchErc20TokenBalanceResponse::class.java)
+        }
+
+        verify("correct ERC20 balance is returned") {
+            assertThat(erc20AccountBalance).withMessage()
+                .isEqualTo(
+                    FetchErc20TokenBalanceResponse(
+                        walletAddress = accountBalance.address.rawValue,
+                        tokenBalance = accountBalance.balance.rawValue,
+                        tokenAddress = contractAddress.rawValue
+                    )
+                )
+        }
+    }
+
+    @Test
+    fun mustReturn404NotFoundWhenFetchingErc20BalanceOfNonExistentMessage() {
+        suppose("some fixed date-time will be returned") {
+            given(utcDateTimeProvider.getUtcDateTime())
+                .willReturn(TestData.SIGNED_MESSAGE.createdAt)
+        }
+
+        val contractAddress = ContractAddress("abc")
+
+        verify("404 is returned for non-existent message") {
+            val response = mockMvc.perform(
+                MockMvcRequestBuilders.get(
+                    "/info/${chainId.value}/${TestData.SIGNED_MESSAGE.id}/erc20-balance/${contractAddress.rawValue}"
+                )
+            )
+                .andExpect(MockMvcResultMatchers.status().isNotFound)
+                .andReturn()
+
+            verifyResponseErrorCode(response, ErrorCode.RESOURCE_NOT_FOUND)
+        }
+    }
+
+    @Test
+    fun mustReturn412PreconditionFailedWhenFetchingErc20BalanceOfExpiredMessage() {
+        suppose("some fixed date-time will be returned") {
+            given(utcDateTimeProvider.getUtcDateTime())
+                .willReturn(TestData.SIGNED_MESSAGE.validUntil + Duration.ofMinutes(1L))
+        }
+
+        suppose("some signed message is in the database") {
+            signedVerificationMessageRepository.store(TestData.SIGNED_MESSAGE)
+        }
+
+        val contractAddress = ContractAddress("abc")
+
+        verify("412 is returned for expired message") {
+            val response = mockMvc.perform(
+                MockMvcRequestBuilders.get(
+                    "/info/${chainId.value}/${TestData.SIGNED_MESSAGE.id}/erc20-balance/${contractAddress.rawValue}"
+                )
+            )
+                .andExpect(MockMvcResultMatchers.status().isPreconditionFailed)
+                .andReturn()
+
+            verifyResponseErrorCode(response, ErrorCode.VALIDATION_MESSAGE_EXPIRED)
+        }
+    }
+
+    @Test
+    fun mustReturn400BadRequestWhenFetchingErc20BalanceOfNonExistentTokenContract() {
+        suppose("some fixed date-time will be returned") {
+            given(utcDateTimeProvider.getUtcDateTime())
+                .willReturn(TestData.SIGNED_MESSAGE.createdAt)
+        }
+
+        suppose("some signed message is in the database") {
+            signedVerificationMessageRepository.store(TestData.SIGNED_MESSAGE)
+        }
+
+        val contractAddress = ContractAddress("abc")
+
+        verify("400 is returned for invalid cotnract address") {
+            val response = mockMvc.perform(
+                MockMvcRequestBuilders.get(
+                    "/info/${chainId.value}/${TestData.SIGNED_MESSAGE.id}/erc20-balance/${contractAddress.rawValue}"
+                )
+            )
+                .andExpect(MockMvcResultMatchers.status().isBadRequest)
+                .andReturn()
+
+            verifyResponseErrorCode(response, ErrorCode.BLOCKCHAIN_READ_ERROR)
+        }
+    }
+
+    private fun <T> RemoteCall<T>.sendAndMine(): T {
+        val future = sendAsync()
+        hardhatContainer.waitAndMine()
+        return future.get()
+    }
+}

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -32,3 +32,16 @@ Verifies verification message signature. Path argument is the message ID.
 include::{snippets}/VerificationControllerApiTest/mustCorrectlyVerifyValidMessageSignature/http-request.adoc[]
 .Response
 include::{snippets}/VerificationControllerApiTest/mustCorrectlyVerifyValidMessageSignature/http-response.adoc[]
+
+== Blockchain Into API
+All endpoints are public and do not require `Authorization: Bearer JWT` header.
+
+=== Fetch ERC20 balance for verified account
+Fetches ERC20 balance of specified contract address for the account which signed verification message with given ID.
+Chain ID, message ID and contract address are provided as path arguments, in that order. Block number can be provided as
+an optional query parameter.
+
+.Request
+include::{snippets}/BlockchainInfoControllerApiTest/mustCorrectlyFetchErc20Balance/http-request.adoc[]
+.Response
+include::{snippets}/BlockchainInfoControllerApiTest/mustCorrectlyFetchErc20Balance/http-response.adoc[]

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/config/WebSecurityConfig.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/config/WebSecurityConfig.kt
@@ -74,6 +74,7 @@ class WebSecurityConfig(private val objectMapper: ObjectMapper) : WebSecurityCon
             .antMatchers("/public/**").permitAll()
             .antMatchers("/docs/index.html").permitAll()
             .antMatchers("/verification/**").permitAll()
+            .antMatchers("/info/**").permitAll()
             .anyRequest().authenticated()
             .and()
             .exceptionHandling().authenticationEntryPoint(authenticationHandler).and()

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/controller/BlockchainInfoController.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/controller/BlockchainInfoController.kt
@@ -1,0 +1,54 @@
+package com.ampnet.blockchainapiservice.controller
+
+import com.ampnet.blockchainapiservice.model.response.FetchErc20TokenBalanceResponse
+import com.ampnet.blockchainapiservice.service.BlockchainInfoService
+import com.ampnet.blockchainapiservice.util.BlockName
+import com.ampnet.blockchainapiservice.util.BlockNumber
+import com.ampnet.blockchainapiservice.util.ChainId
+import com.ampnet.blockchainapiservice.util.ContractAddress
+import mu.KLogging
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.math.BigInteger
+import java.util.UUID
+
+@RestController
+class BlockchainInfoController(private val blockchainInfoService: BlockchainInfoService) {
+
+    companion object : KLogging()
+
+    @GetMapping("/info/{chainId}/{messageId}/erc20-balance/{contractAddress}")
+    fun fetchErc20TokenBalance(
+        @PathVariable("chainId") rawChainId: Long,
+        @PathVariable("messageId") messageId: UUID,
+        @PathVariable("contractAddress") rawContractAddress: String,
+        @RequestParam(required = false) blockNumber: BigInteger?
+    ): ResponseEntity<FetchErc20TokenBalanceResponse> {
+        val chainId = ChainId(rawChainId)
+        val contractAddress = ContractAddress(rawContractAddress)
+        val block = blockNumber?.let { BlockNumber(it) } ?: BlockName.LATEST
+
+        logger.debug {
+            "Fetching ERC20 balance, chainId: $chainId, messageId: $messageId," +
+                " contractAddress: $contractAddress, block: $block"
+        }
+
+        val accountBalance = blockchainInfoService.fetchErc20AccountBalanceFromSignedMessage(
+            messageId = messageId,
+            chainId = chainId,
+            contractAddress = contractAddress,
+            block = block
+        )
+
+        return ResponseEntity.ok(
+            FetchErc20TokenBalanceResponse(
+                walletAddress = accountBalance.address.rawValue,
+                tokenBalance = accountBalance.balance.rawValue,
+                tokenAddress = contractAddress.rawValue
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/model/response/FetchErc20TokenBalanceResponse.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/model/response/FetchErc20TokenBalanceResponse.kt
@@ -1,0 +1,12 @@
+package com.ampnet.blockchainapiservice.model.response
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer
+import java.math.BigInteger
+
+data class FetchErc20TokenBalanceResponse(
+    val walletAddress: String,
+    @JsonSerialize(using = ToStringSerializer::class)
+    val tokenBalance: BigInteger,
+    val tokenAddress: String
+)

--- a/src/test/kotlin/com/ampnet/blockchainapiservice/controller/BlockchainInfoControllerTest.kt
+++ b/src/test/kotlin/com/ampnet/blockchainapiservice/controller/BlockchainInfoControllerTest.kt
@@ -1,0 +1,111 @@
+package com.ampnet.blockchainapiservice.controller
+
+import com.ampnet.blockchainapiservice.TestBase
+import com.ampnet.blockchainapiservice.blockchain.properties.Chain
+import com.ampnet.blockchainapiservice.model.response.FetchErc20TokenBalanceResponse
+import com.ampnet.blockchainapiservice.service.BlockchainInfoService
+import com.ampnet.blockchainapiservice.util.AccountBalance
+import com.ampnet.blockchainapiservice.util.Balance
+import com.ampnet.blockchainapiservice.util.BlockName
+import com.ampnet.blockchainapiservice.util.BlockNumber
+import com.ampnet.blockchainapiservice.util.ContractAddress
+import com.ampnet.blockchainapiservice.util.WalletAddress
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
+import org.springframework.http.ResponseEntity
+import java.math.BigInteger
+import java.util.UUID
+
+class BlockchainInfoControllerTest : TestBase() {
+
+    @Test
+    fun mustReturnCorrectErc20TokenBalanceWhenBlockNumberIsNotProvided() {
+        val accountBalance = AccountBalance(WalletAddress("123"), Balance(BigInteger("10000")))
+        val messageId = UUID.randomUUID()
+        val chainId = Chain.HARDHAT_TESTNET.id
+        val contractAddress = ContractAddress("abc")
+
+        val service = mock<BlockchainInfoService>()
+
+        suppose("service will return some account balance") {
+            given(
+                service.fetchErc20AccountBalanceFromSignedMessage(
+                    messageId = messageId,
+                    chainId = chainId,
+                    contractAddress = contractAddress,
+                    block = BlockName.LATEST
+                )
+            )
+                .willReturn(accountBalance)
+        }
+
+        val controller = BlockchainInfoController(service)
+
+        verify("controller returns correct response") {
+            val result = controller.fetchErc20TokenBalance(
+                rawChainId = chainId.value,
+                messageId = messageId,
+                rawContractAddress = contractAddress.rawValue,
+                blockNumber = null
+            )
+
+            assertThat(result).withMessage()
+                .isEqualTo(
+                    ResponseEntity.ok(
+                        FetchErc20TokenBalanceResponse(
+                            walletAddress = accountBalance.address.rawValue,
+                            tokenBalance = accountBalance.balance.rawValue,
+                            tokenAddress = contractAddress.rawValue
+                        )
+                    )
+                )
+        }
+    }
+
+    @Test
+    fun mustReturnCorrectErc20TokenBalanceForSpecifiedBlockNumber() {
+        val accountBalance = AccountBalance(WalletAddress("123"), Balance(BigInteger("10000")))
+        val messageId = UUID.randomUUID()
+        val chainId = Chain.HARDHAT_TESTNET.id
+        val contractAddress = ContractAddress("abc")
+        val blockNumber = BlockNumber(BigInteger("456"))
+
+        val service = mock<BlockchainInfoService>()
+
+        suppose("service will return some account balance") {
+            given(
+                service.fetchErc20AccountBalanceFromSignedMessage(
+                    messageId = messageId,
+                    chainId = chainId,
+                    contractAddress = contractAddress,
+                    block = blockNumber
+                )
+            )
+                .willReturn(accountBalance)
+        }
+
+        val controller = BlockchainInfoController(service)
+
+        verify("controller returns correct response") {
+            val result = controller.fetchErc20TokenBalance(
+                rawChainId = chainId.value,
+                messageId = messageId,
+                rawContractAddress = contractAddress.rawValue,
+                blockNumber = blockNumber.value
+            )
+
+            assertThat(result).withMessage()
+                .isEqualTo(
+                    ResponseEntity.ok(
+                        FetchErc20TokenBalanceResponse(
+                            walletAddress = accountBalance.address.rawValue,
+                            tokenBalance = accountBalance.balance.rawValue,
+                            tokenAddress = contractAddress.rawValue
+                        )
+                    )
+                )
+        }
+    }
+}


### PR DESCRIPTION
Adds API to fetch ERC20 token balance for verified accounts. Subtask 3/3 of [SD-598](https://linear.app/ampnet/issue/SD-598/provide-api-endpoint-to-fetch-token-balance-for-specified-signature).

Please review #8  before this PR.