### PR TITLE
SD-625: add support for arbitrary chains

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -39,7 +39,7 @@ All endpoints are public and do not require `Authorization: Bearer JWT` header.
 === Fetch ERC20 balance for verified account
 Fetches ERC20 balance of specified contract address for the account which signed verification message with given ID.
 Chain ID, message ID and contract address are provided as path arguments, in that order. Block number can be provided as
-an optional query parameter.
+an optional query parameter `blockNumber`.
 
 .Request
 include::{snippets}/BlockchainInfoControllerApiTest/mustCorrectlyFetchErc20Balance/http-request.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -34,7 +34,8 @@ include::{snippets}/VerificationControllerApiTest/mustCorrectlyVerifyValidMessag
 include::{snippets}/VerificationControllerApiTest/mustCorrectlyVerifyValidMessageSignature/http-response.adoc[]
 
 == Blockchain Into API
-All endpoints are public and do not require `Authorization: Bearer JWT` header.
+All endpoints are public and do not require `Authorization: Bearer JWT` header. Custom RPC URL can be specified via
+optional `X-RPC-URL` header - this will override the default RPC URL for the specified chain ID.
 
 === Fetch ERC20 balance for verified account
 Fetches ERC20 balance of specified contract address for the account which signed verification message with given ID.

--- a/src/integTest/kotlin/com/ampnet/blockchainapiservice/blockchain/Web3jBlockchainServiceIntegTest.kt
+++ b/src/integTest/kotlin/com/ampnet/blockchainapiservice/blockchain/Web3jBlockchainServiceIntegTest.kt
@@ -2,11 +2,13 @@ package com.ampnet.blockchainapiservice.blockchain
 
 import com.ampnet.blockchainapiservice.TestBase
 import com.ampnet.blockchainapiservice.blockchain.properties.Chain
+import com.ampnet.blockchainapiservice.blockchain.properties.ChainSpec
 import com.ampnet.blockchainapiservice.config.ApplicationProperties
 import com.ampnet.blockchainapiservice.exception.BlockchainReadException
 import com.ampnet.blockchainapiservice.testcontainers.HardhatTestContainer
 import com.ampnet.blockchainapiservice.util.AccountBalance
 import com.ampnet.blockchainapiservice.util.Balance
+import com.ampnet.blockchainapiservice.util.ChainId
 import com.ampnet.blockchainapiservice.util.ContractAddress
 import com.ampnet.blockchainapiservice.util.WalletAddress
 import org.assertj.core.api.Assertions.assertThat
@@ -42,7 +44,7 @@ class Web3jBlockchainServiceIntegTest : TestBase() {
         verify("correct ERC20 balance is fetched for latest block") {
             val service = Web3jBlockchainService(hardhatProperties())
             val fetchedAccountBalance = service.fetchErc20AccountBalance(
-                chainId = Chain.HARDHAT_TESTNET.id,
+                chainSpec = Chain.HARDHAT_TESTNET.id.toSpec(),
                 contractAddress = ContractAddress(contract.contractAddress),
                 walletAddress = accountBalance.address
             )
@@ -78,7 +80,7 @@ class Web3jBlockchainServiceIntegTest : TestBase() {
 
         verify("correct ERC20 balance is fetched for block number before ERC20 transfer is made") {
             val fetchedAccountBalance = service.fetchErc20AccountBalance(
-                chainId = Chain.HARDHAT_TESTNET.id,
+                chainSpec = Chain.HARDHAT_TESTNET.id.toSpec(),
                 contractAddress = ContractAddress(contract.contractAddress),
                 walletAddress = accountBalance.address,
                 block = blockNumberBeforeSendingBalance
@@ -92,7 +94,7 @@ class Web3jBlockchainServiceIntegTest : TestBase() {
 
         verify("correct ERC20 balance is fetched for block number after ERC20 transfer is made") {
             val fetchedAccountBalance = service.fetchErc20AccountBalance(
-                chainId = Chain.HARDHAT_TESTNET.id,
+                chainSpec = Chain.HARDHAT_TESTNET.id.toSpec(),
                 contractAddress = ContractAddress(contract.contractAddress),
                 walletAddress = accountBalance.address,
                 block = blockNumberAfterSendingBalance
@@ -110,7 +112,7 @@ class Web3jBlockchainServiceIntegTest : TestBase() {
 
             assertThrows<BlockchainReadException>(message) {
                 service.fetchErc20AccountBalance(
-                    chainId = Chain.HARDHAT_TESTNET.id,
+                    chainSpec = Chain.HARDHAT_TESTNET.id.toSpec(),
                     contractAddress = ContractAddress(accounts[0].address),
                     walletAddress = WalletAddress(accounts[0].address)
                 )
@@ -132,4 +134,6 @@ class Web3jBlockchainServiceIntegTest : TestBase() {
     }
 
     private fun hardhatProperties() = ApplicationProperties().apply { infuraId = hardhatContainer.mappedPort }
+
+    private fun ChainId.toSpec() = ChainSpec(this, null)
 }

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/blockchain/BlockchainService.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/blockchain/BlockchainService.kt
@@ -1,15 +1,15 @@
 package com.ampnet.blockchainapiservice.blockchain
 
+import com.ampnet.blockchainapiservice.blockchain.properties.ChainSpec
 import com.ampnet.blockchainapiservice.util.AccountBalance
 import com.ampnet.blockchainapiservice.util.BlockName
 import com.ampnet.blockchainapiservice.util.BlockParameter
-import com.ampnet.blockchainapiservice.util.ChainId
 import com.ampnet.blockchainapiservice.util.ContractAddress
 import com.ampnet.blockchainapiservice.util.WalletAddress
 
 interface BlockchainService {
     fun fetchErc20AccountBalance(
-        chainId: ChainId,
+        chainSpec: ChainSpec,
         contractAddress: ContractAddress,
         walletAddress: WalletAddress,
         block: BlockParameter = BlockName.LATEST

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/blockchain/Web3jBlockchainService.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/blockchain/Web3jBlockchainService.kt
@@ -1,12 +1,12 @@
 package com.ampnet.blockchainapiservice.blockchain
 
 import com.ampnet.blockchainapiservice.blockchain.properties.ChainPropertiesHandler
+import com.ampnet.blockchainapiservice.blockchain.properties.ChainSpec
 import com.ampnet.blockchainapiservice.config.ApplicationProperties
 import com.ampnet.blockchainapiservice.exception.BlockchainReadException
 import com.ampnet.blockchainapiservice.util.AccountBalance
 import com.ampnet.blockchainapiservice.util.Balance
 import com.ampnet.blockchainapiservice.util.BlockParameter
-import com.ampnet.blockchainapiservice.util.ChainId
 import com.ampnet.blockchainapiservice.util.ContractAddress
 import com.ampnet.blockchainapiservice.util.WalletAddress
 import mu.KLogging
@@ -23,16 +23,16 @@ class Web3jBlockchainService(applicationProperties: ApplicationProperties) : Blo
     private val chainHandler = ChainPropertiesHandler(applicationProperties)
 
     override fun fetchErc20AccountBalance(
-        chainId: ChainId,
+        chainSpec: ChainSpec,
         contractAddress: ContractAddress,
         walletAddress: WalletAddress,
         block: BlockParameter
     ): AccountBalance {
         logger.debug {
-            "Fetching ERC20 balance, chainId: $chainId, contractAddress: $contractAddress," +
+            "Fetching ERC20 balance, chainSpec: $chainSpec, contractAddress: $contractAddress," +
                 " walletAddress: $walletAddress, block: $block"
         }
-        val blockchainProperties = chainHandler.getBlockchainProperties(chainId)
+        val blockchainProperties = chainHandler.getBlockchainProperties(chainSpec)
         val contract = IERC20.load(
             contractAddress.rawValue,
             blockchainProperties.web3j,
@@ -45,7 +45,8 @@ class Web3jBlockchainService(applicationProperties: ApplicationProperties) : Blo
         return contract.balanceOf(walletAddress.rawValue).sendSafely()
             ?.let { AccountBalance(walletAddress, Balance(it)) }
             ?: throw BlockchainReadException(
-                "Unable to read ERC20 contract at address: ${contractAddress.rawValue} on chain ID: ${chainId.value}"
+                "Unable to read ERC20 contract at address: ${contractAddress.rawValue}" +
+                    " on chain ID: ${chainSpec.chainId.value}"
             )
     }
 

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/blockchain/properties/ChainPropertiesHandler.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/blockchain/properties/ChainPropertiesHandler.kt
@@ -11,9 +11,15 @@ class ChainPropertiesHandler(private val applicationProperties: ApplicationPrope
 
     private val blockchainPropertiesMap = mutableMapOf<ChainId, ChainPropertiesWithServices>()
 
-    fun getBlockchainProperties(chainId: ChainId): ChainPropertiesWithServices {
-        return blockchainPropertiesMap.computeIfAbsent(chainId) {
-            generateBlockchainProperties(getChain(it))
+    fun getBlockchainProperties(chainSpec: ChainSpec): ChainPropertiesWithServices {
+        return if (chainSpec.rpcUrl != null) {
+            ChainPropertiesWithServices(
+                web3j = Web3j.build(HttpService(chainSpec.rpcUrl))
+            )
+        } else {
+            blockchainPropertiesMap.computeIfAbsent(chainSpec.chainId) {
+                generateBlockchainProperties(getChain(it))
+            }
         }
     }
 

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/blockchain/properties/ChainSpec.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/blockchain/properties/ChainSpec.kt
@@ -1,0 +1,5 @@
+package com.ampnet.blockchainapiservice.blockchain.properties
+
+import com.ampnet.blockchainapiservice.util.ChainId
+
+data class ChainSpec(val chainId: ChainId, val rpcUrl: String?)

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/config/Converters.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/config/Converters.kt
@@ -1,0 +1,27 @@
+import com.ampnet.blockchainapiservice.util.BlockNumber
+import com.ampnet.blockchainapiservice.util.ChainId
+import com.ampnet.blockchainapiservice.util.ContractAddress
+import com.ampnet.blockchainapiservice.util.WalletAddress
+import org.springframework.core.convert.converter.Converter
+import org.springframework.stereotype.Component
+import java.math.BigInteger
+
+@Component
+class StringToChainIdConverter : Converter<String, ChainId> {
+    override fun convert(source: String) = ChainId(source.toLong())
+}
+
+@Component
+class StringToBlockNumberConverter : Converter<String, BlockNumber> {
+    override fun convert(source: String) = BlockNumber(BigInteger(source))
+}
+
+@Component
+class StringToContractAddressConverter : Converter<String, ContractAddress> {
+    override fun convert(source: String) = ContractAddress(source)
+}
+
+@Component
+class StringToWalletAddressConverter : Converter<String, WalletAddress> {
+    override fun convert(source: String) = WalletAddress(source)
+}

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/config/WebConfig.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/config/WebConfig.kt
@@ -1,0 +1,13 @@
+package com.ampnet.blockchainapiservice.config
+
+import com.ampnet.blockchainapiservice.config.binding.ChainSpecResolver
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebConfig : WebMvcConfigurer {
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(ChainSpecResolver())
+    }
+}

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/config/binding/ChainSpecResolver.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/config/binding/ChainSpecResolver.kt
@@ -1,0 +1,43 @@
+package com.ampnet.blockchainapiservice.config.binding
+
+import com.ampnet.blockchainapiservice.blockchain.properties.ChainSpec
+import com.ampnet.blockchainapiservice.config.binding.annotation.ChainBinding
+import com.ampnet.blockchainapiservice.util.ChainId
+import org.springframework.core.MethodParameter
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+import org.springframework.web.servlet.HandlerMapping
+import javax.servlet.http.HttpServletRequest
+
+class ChainSpecResolver : HandlerMethodArgumentResolver {
+
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        return parameter.parameterType == ChainSpec::class.java &&
+            parameter.hasParameterAnnotation(ChainBinding::class.java)
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        nativeWebRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?
+    ): ChainSpec {
+        val httpServletRequest = nativeWebRequest.getNativeRequest(HttpServletRequest::class.java)
+
+        @Suppress("UNCHECKED_CAST")
+        val pathVariables = httpServletRequest?.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)
+            as? Map<String, String>
+
+        val chainIdPathVariable = parameter.getParameterAnnotation(ChainBinding::class.java)?.chainIdPathVariable
+
+        // chainId is a mandatory path variable
+        val chainId = pathVariables?.get(chainIdPathVariable)?.let { ChainId(it.toLong()) }
+            ?: throw IllegalStateException("Path variable \"chainId\" is missing from the controller specification.")
+        // RPC URL is an optional header
+        val rpcUrl = httpServletRequest.getHeader("X-RPC-URL")
+
+        return ChainSpec(chainId, rpcUrl)
+    }
+}

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/config/binding/ChainSpecResolver.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/config/binding/ChainSpecResolver.kt
@@ -13,6 +13,10 @@ import javax.servlet.http.HttpServletRequest
 
 class ChainSpecResolver : HandlerMethodArgumentResolver {
 
+    companion object {
+        const val RPC_URL_HEADER = "X-RPC-URL"
+    }
+
     override fun supportsParameter(parameter: MethodParameter): Boolean {
         return parameter.parameterType == ChainSpec::class.java &&
             parameter.hasParameterAnnotation(ChainBinding::class.java)
@@ -34,9 +38,11 @@ class ChainSpecResolver : HandlerMethodArgumentResolver {
 
         // chainId is a mandatory path variable
         val chainId = pathVariables?.get(chainIdPathVariable)?.let { ChainId(it.toLong()) }
-            ?: throw IllegalStateException("Path variable \"chainId\" is missing from the controller specification.")
+            ?: throw IllegalStateException(
+                "Path variable \"$chainIdPathVariable\" is missing from the controller specification."
+            )
         // RPC URL is an optional header
-        val rpcUrl = httpServletRequest.getHeader("X-RPC-URL")
+        val rpcUrl = httpServletRequest.getHeader(RPC_URL_HEADER)
 
         return ChainSpec(chainId, rpcUrl)
     }

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/config/binding/Converters.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/config/binding/Converters.kt
@@ -1,15 +1,11 @@
+package com.ampnet.blockchainapiservice.config.binding
+
 import com.ampnet.blockchainapiservice.util.BlockNumber
-import com.ampnet.blockchainapiservice.util.ChainId
 import com.ampnet.blockchainapiservice.util.ContractAddress
 import com.ampnet.blockchainapiservice.util.WalletAddress
 import org.springframework.core.convert.converter.Converter
 import org.springframework.stereotype.Component
 import java.math.BigInteger
-
-@Component
-class StringToChainIdConverter : Converter<String, ChainId> {
-    override fun convert(source: String) = ChainId(source.toLong())
-}
 
 @Component
 class StringToBlockNumberConverter : Converter<String, BlockNumber> {

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/config/binding/annotation/ChainBinding.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/config/binding/annotation/ChainBinding.kt
@@ -1,0 +1,5 @@
+package com.ampnet.blockchainapiservice.config.binding.annotation
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.VALUE_PARAMETER)
+annotation class ChainBinding(val chainIdPathVariable: String = "chainId")

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/controller/BlockchainInfoController.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/controller/BlockchainInfoController.kt
@@ -36,7 +36,7 @@ class BlockchainInfoController(private val blockchainInfoService: BlockchainInfo
 
         val accountBalance = blockchainInfoService.fetchErc20AccountBalanceFromSignedMessage(
             messageId = messageId,
-            chainId = chainSpec.chainId,
+            chainSpec = chainSpec,
             contractAddress = contractAddress,
             block = block
         )

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/controller/BlockchainInfoController.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/controller/BlockchainInfoController.kt
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import java.math.BigInteger
 import java.util.UUID
 
 @RestController
@@ -22,14 +21,12 @@ class BlockchainInfoController(private val blockchainInfoService: BlockchainInfo
 
     @GetMapping("/info/{chainId}/{messageId}/erc20-balance/{contractAddress}")
     fun fetchErc20TokenBalance(
-        @PathVariable("chainId") rawChainId: Long,
-        @PathVariable("messageId") messageId: UUID,
-        @PathVariable("contractAddress") rawContractAddress: String,
-        @RequestParam(required = false) blockNumber: BigInteger?
+        @PathVariable chainId: ChainId,
+        @PathVariable messageId: UUID,
+        @PathVariable contractAddress: ContractAddress,
+        @RequestParam(required = false) blockNumber: BlockNumber?
     ): ResponseEntity<FetchErc20TokenBalanceResponse> {
-        val chainId = ChainId(rawChainId)
-        val contractAddress = ContractAddress(rawContractAddress)
-        val block = blockNumber?.let { BlockNumber(it) } ?: BlockName.LATEST
+        val block = blockNumber ?: BlockName.LATEST
 
         logger.debug {
             "Fetching ERC20 balance, chainId: $chainId, messageId: $messageId," +

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/controller/BlockchainInfoController.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/controller/BlockchainInfoController.kt
@@ -1,10 +1,11 @@
 package com.ampnet.blockchainapiservice.controller
 
+import com.ampnet.blockchainapiservice.blockchain.properties.ChainSpec
+import com.ampnet.blockchainapiservice.config.binding.annotation.ChainBinding
 import com.ampnet.blockchainapiservice.model.response.FetchErc20TokenBalanceResponse
 import com.ampnet.blockchainapiservice.service.BlockchainInfoService
 import com.ampnet.blockchainapiservice.util.BlockName
 import com.ampnet.blockchainapiservice.util.BlockNumber
-import com.ampnet.blockchainapiservice.util.ChainId
 import com.ampnet.blockchainapiservice.util.ContractAddress
 import mu.KLogging
 import org.springframework.http.ResponseEntity
@@ -21,7 +22,7 @@ class BlockchainInfoController(private val blockchainInfoService: BlockchainInfo
 
     @GetMapping("/info/{chainId}/{messageId}/erc20-balance/{contractAddress}")
     fun fetchErc20TokenBalance(
-        @PathVariable chainId: ChainId,
+        @ChainBinding chainSpec: ChainSpec,
         @PathVariable messageId: UUID,
         @PathVariable contractAddress: ContractAddress,
         @RequestParam(required = false) blockNumber: BlockNumber?
@@ -29,13 +30,13 @@ class BlockchainInfoController(private val blockchainInfoService: BlockchainInfo
         val block = blockNumber ?: BlockName.LATEST
 
         logger.debug {
-            "Fetching ERC20 balance, chainId: $chainId, messageId: $messageId," +
+            "Fetching ERC20 balance, chainSpec: $chainSpec, messageId: $messageId," +
                 " contractAddress: $contractAddress, block: $block"
         }
 
         val accountBalance = blockchainInfoService.fetchErc20AccountBalanceFromSignedMessage(
             messageId = messageId,
-            chainId = chainId,
+            chainId = chainSpec.chainId,
             contractAddress = contractAddress,
             block = block
         )

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/controller/VerificationController.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/controller/VerificationController.kt
@@ -20,10 +20,10 @@ class VerificationController(private val verificationService: VerificationServic
 
     @PostMapping("/verification/generate/{walletAddress}")
     fun generateVerificationMessage(
-        @PathVariable walletAddress: String
+        @PathVariable walletAddress: WalletAddress
     ): ResponseEntity<GenerateVerificationMessageResponse> {
         logger.info { "Request generation of verification message for wallet address: $walletAddress" }
-        val unsignedMessage = verificationService.createUnsignedVerificationMessage(WalletAddress(walletAddress))
+        val unsignedMessage = verificationService.createUnsignedVerificationMessage(walletAddress)
         return ResponseEntity.ok(
             GenerateVerificationMessageResponse(
                 id = unsignedMessage.id,

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/service/BlockchainInfoService.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/service/BlockchainInfoService.kt
@@ -1,16 +1,16 @@
 package com.ampnet.blockchainapiservice.service
 
+import com.ampnet.blockchainapiservice.blockchain.properties.ChainSpec
 import com.ampnet.blockchainapiservice.util.AccountBalance
 import com.ampnet.blockchainapiservice.util.BlockName
 import com.ampnet.blockchainapiservice.util.BlockParameter
-import com.ampnet.blockchainapiservice.util.ChainId
 import com.ampnet.blockchainapiservice.util.ContractAddress
 import java.util.UUID
 
 interface BlockchainInfoService {
     fun fetchErc20AccountBalanceFromSignedMessage(
         messageId: UUID,
-        chainId: ChainId,
+        chainSpec: ChainSpec,
         contractAddress: ContractAddress,
         block: BlockParameter = BlockName.LATEST
     ): AccountBalance

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/service/BlockchainInfoServiceImpl.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/service/BlockchainInfoServiceImpl.kt
@@ -1,12 +1,12 @@
 package com.ampnet.blockchainapiservice.service
 
 import com.ampnet.blockchainapiservice.blockchain.BlockchainService
+import com.ampnet.blockchainapiservice.blockchain.properties.ChainSpec
 import com.ampnet.blockchainapiservice.exception.ExpiredValidationMessageException
 import com.ampnet.blockchainapiservice.exception.ResourceNotFoundException
 import com.ampnet.blockchainapiservice.repository.SignedVerificationMessageRepository
 import com.ampnet.blockchainapiservice.util.AccountBalance
 import com.ampnet.blockchainapiservice.util.BlockParameter
-import com.ampnet.blockchainapiservice.util.ChainId
 import com.ampnet.blockchainapiservice.util.ContractAddress
 import mu.KLogging
 import org.springframework.stereotype.Service
@@ -23,12 +23,12 @@ class BlockchainInfoServiceImpl(
 
     override fun fetchErc20AccountBalanceFromSignedMessage(
         messageId: UUID,
-        chainId: ChainId,
+        chainSpec: ChainSpec,
         contractAddress: ContractAddress,
         block: BlockParameter
     ): AccountBalance {
         logger.debug {
-            "Fetching ERC20 balance, messageId: $messageId, chainId: $chainId," +
+            "Fetching ERC20 balance, messageId: $messageId, chainSpec: $chainSpec," +
                 " contractAddress: $contractAddress, block: $block"
         }
 
@@ -44,7 +44,7 @@ class BlockchainInfoServiceImpl(
         logger.debug { "Message with ID $messageId was signed by ${signedMessage.walletAddress}" }
 
         return blockchainService.fetchErc20AccountBalance(
-            chainId = chainId,
+            chainSpec = chainSpec,
             contractAddress = contractAddress,
             walletAddress = signedMessage.walletAddress,
             block = block

--- a/src/test/kotlin/com/ampnet/blockchainapiservice/controller/BlockchainInfoControllerTest.kt
+++ b/src/test/kotlin/com/ampnet/blockchainapiservice/controller/BlockchainInfoControllerTest.kt
@@ -45,9 +45,9 @@ class BlockchainInfoControllerTest : TestBase() {
 
         verify("controller returns correct response") {
             val result = controller.fetchErc20TokenBalance(
-                rawChainId = chainId.value,
+                chainId = chainId,
                 messageId = messageId,
-                rawContractAddress = contractAddress.rawValue,
+                contractAddress = contractAddress,
                 blockNumber = null
             )
 
@@ -90,10 +90,10 @@ class BlockchainInfoControllerTest : TestBase() {
 
         verify("controller returns correct response") {
             val result = controller.fetchErc20TokenBalance(
-                rawChainId = chainId.value,
+                chainId = chainId,
                 messageId = messageId,
-                rawContractAddress = contractAddress.rawValue,
-                blockNumber = blockNumber.value
+                contractAddress = contractAddress,
+                blockNumber = blockNumber
             )
 
             assertThat(result).withMessage()

--- a/src/test/kotlin/com/ampnet/blockchainapiservice/controller/BlockchainInfoControllerTest.kt
+++ b/src/test/kotlin/com/ampnet/blockchainapiservice/controller/BlockchainInfoControllerTest.kt
@@ -9,6 +9,7 @@ import com.ampnet.blockchainapiservice.util.AccountBalance
 import com.ampnet.blockchainapiservice.util.Balance
 import com.ampnet.blockchainapiservice.util.BlockName
 import com.ampnet.blockchainapiservice.util.BlockNumber
+import com.ampnet.blockchainapiservice.util.ChainId
 import com.ampnet.blockchainapiservice.util.ContractAddress
 import com.ampnet.blockchainapiservice.util.WalletAddress
 import org.assertj.core.api.Assertions.assertThat
@@ -25,7 +26,7 @@ class BlockchainInfoControllerTest : TestBase() {
     fun mustReturnCorrectErc20TokenBalanceWhenBlockNumberIsNotProvided() {
         val accountBalance = AccountBalance(WalletAddress("123"), Balance(BigInteger("10000")))
         val messageId = UUID.randomUUID()
-        val chainId = Chain.HARDHAT_TESTNET.id
+        val chainSpec = Chain.HARDHAT_TESTNET.id.toSpec()
         val contractAddress = ContractAddress("abc")
 
         val service = mock<BlockchainInfoService>()
@@ -34,7 +35,7 @@ class BlockchainInfoControllerTest : TestBase() {
             given(
                 service.fetchErc20AccountBalanceFromSignedMessage(
                     messageId = messageId,
-                    chainId = chainId,
+                    chainSpec = chainSpec,
                     contractAddress = contractAddress,
                     block = BlockName.LATEST
                 )
@@ -46,7 +47,7 @@ class BlockchainInfoControllerTest : TestBase() {
 
         verify("controller returns correct response") {
             val result = controller.fetchErc20TokenBalance(
-                chainSpec = ChainSpec(chainId, null),
+                chainSpec = chainSpec,
                 messageId = messageId,
                 contractAddress = contractAddress,
                 blockNumber = null
@@ -69,7 +70,7 @@ class BlockchainInfoControllerTest : TestBase() {
     fun mustReturnCorrectErc20TokenBalanceForSpecifiedBlockNumber() {
         val accountBalance = AccountBalance(WalletAddress("123"), Balance(BigInteger("10000")))
         val messageId = UUID.randomUUID()
-        val chainId = Chain.HARDHAT_TESTNET.id
+        val chainSpec = Chain.HARDHAT_TESTNET.id.toSpec()
         val contractAddress = ContractAddress("abc")
         val blockNumber = BlockNumber(BigInteger("456"))
 
@@ -79,7 +80,7 @@ class BlockchainInfoControllerTest : TestBase() {
             given(
                 service.fetchErc20AccountBalanceFromSignedMessage(
                     messageId = messageId,
-                    chainId = chainId,
+                    chainSpec = chainSpec,
                     contractAddress = contractAddress,
                     block = blockNumber
                 )
@@ -91,7 +92,7 @@ class BlockchainInfoControllerTest : TestBase() {
 
         verify("controller returns correct response") {
             val result = controller.fetchErc20TokenBalance(
-                chainSpec = ChainSpec(chainId, null),
+                chainSpec = chainSpec,
                 messageId = messageId,
                 contractAddress = contractAddress,
                 blockNumber = blockNumber
@@ -109,4 +110,6 @@ class BlockchainInfoControllerTest : TestBase() {
                 )
         }
     }
+
+    private fun ChainId.toSpec() = ChainSpec(this, null)
 }

--- a/src/test/kotlin/com/ampnet/blockchainapiservice/controller/BlockchainInfoControllerTest.kt
+++ b/src/test/kotlin/com/ampnet/blockchainapiservice/controller/BlockchainInfoControllerTest.kt
@@ -2,6 +2,7 @@ package com.ampnet.blockchainapiservice.controller
 
 import com.ampnet.blockchainapiservice.TestBase
 import com.ampnet.blockchainapiservice.blockchain.properties.Chain
+import com.ampnet.blockchainapiservice.blockchain.properties.ChainSpec
 import com.ampnet.blockchainapiservice.model.response.FetchErc20TokenBalanceResponse
 import com.ampnet.blockchainapiservice.service.BlockchainInfoService
 import com.ampnet.blockchainapiservice.util.AccountBalance
@@ -45,7 +46,7 @@ class BlockchainInfoControllerTest : TestBase() {
 
         verify("controller returns correct response") {
             val result = controller.fetchErc20TokenBalance(
-                chainId = chainId,
+                chainSpec = ChainSpec(chainId, null),
                 messageId = messageId,
                 contractAddress = contractAddress,
                 blockNumber = null
@@ -90,7 +91,7 @@ class BlockchainInfoControllerTest : TestBase() {
 
         verify("controller returns correct response") {
             val result = controller.fetchErc20TokenBalance(
-                chainId = chainId,
+                chainSpec = ChainSpec(chainId, null),
                 messageId = messageId,
                 contractAddress = contractAddress,
                 blockNumber = blockNumber

--- a/src/test/kotlin/com/ampnet/blockchainapiservice/controller/VerificationControllerTest.kt
+++ b/src/test/kotlin/com/ampnet/blockchainapiservice/controller/VerificationControllerTest.kt
@@ -41,7 +41,7 @@ class VerificationControllerTest : TestBase() {
         val controller = VerificationController(service)
 
         verify("controller returns correct response") {
-            val result = controller.generateVerificationMessage(walletAddress.rawValue)
+            val result = controller.generateVerificationMessage(walletAddress)
 
             assertThat(result).withMessage()
                 .isEqualTo(

--- a/src/test/kotlin/com/ampnet/blockchainapiservice/service/BlockchainInfoServiceTest.kt
+++ b/src/test/kotlin/com/ampnet/blockchainapiservice/service/BlockchainInfoServiceTest.kt
@@ -4,12 +4,14 @@ import com.ampnet.blockchainapiservice.TestBase
 import com.ampnet.blockchainapiservice.TestData
 import com.ampnet.blockchainapiservice.blockchain.BlockchainService
 import com.ampnet.blockchainapiservice.blockchain.properties.Chain
+import com.ampnet.blockchainapiservice.blockchain.properties.ChainSpec
 import com.ampnet.blockchainapiservice.exception.ExpiredValidationMessageException
 import com.ampnet.blockchainapiservice.exception.ResourceNotFoundException
 import com.ampnet.blockchainapiservice.repository.SignedVerificationMessageRepository
 import com.ampnet.blockchainapiservice.util.AccountBalance
 import com.ampnet.blockchainapiservice.util.Balance
 import com.ampnet.blockchainapiservice.util.BlockNumber
+import com.ampnet.blockchainapiservice.util.ChainId
 import com.ampnet.blockchainapiservice.util.ContractAddress
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -39,7 +41,7 @@ class BlockchainInfoServiceTest : TestBase() {
                 .willReturn(TestData.SIGNED_MESSAGE.verifiedAt)
         }
 
-        val chainId = Chain.HARDHAT_TESTNET.id
+        val chainSpec = Chain.HARDHAT_TESTNET.id.toSpec()
         val contractAddress = ContractAddress("a")
         val block = BlockNumber(BigInteger("123"))
         val accountBalance = AccountBalance(TestData.SIGNED_MESSAGE.walletAddress, Balance(BigInteger("10000")))
@@ -48,7 +50,7 @@ class BlockchainInfoServiceTest : TestBase() {
         suppose("blockchain service will return ERC20 balance of account") {
             given(
                 blockchainService.fetchErc20AccountBalance(
-                    chainId = chainId,
+                    chainSpec = chainSpec,
                     contractAddress = contractAddress,
                     walletAddress = TestData.SIGNED_MESSAGE.walletAddress,
                     block = block
@@ -65,7 +67,7 @@ class BlockchainInfoServiceTest : TestBase() {
         verify("correct ERC20 balance is fetched") {
             val result = service.fetchErc20AccountBalanceFromSignedMessage(
                 messageId = TestData.SIGNED_MESSAGE.id,
-                chainId = chainId,
+                chainSpec = chainSpec,
                 contractAddress = contractAddress,
                 block = block
             )
@@ -91,7 +93,7 @@ class BlockchainInfoServiceTest : TestBase() {
                 .willReturn(TestData.SIGNED_MESSAGE.validUntil + Duration.ofMinutes(1L))
         }
 
-        val chainId = Chain.HARDHAT_TESTNET.id
+        val chainSpec = Chain.HARDHAT_TESTNET.id.toSpec()
         val contractAddress = ContractAddress("a")
         val block = BlockNumber(BigInteger("123"))
         val blockchainService = mock<BlockchainService>()
@@ -106,7 +108,7 @@ class BlockchainInfoServiceTest : TestBase() {
             assertThrows<ExpiredValidationMessageException>(message) {
                 service.fetchErc20AccountBalanceFromSignedMessage(
                     messageId = TestData.SIGNED_MESSAGE.id,
-                    chainId = chainId,
+                    chainSpec = chainSpec,
                     contractAddress = contractAddress,
                     block = block
                 )
@@ -135,10 +137,12 @@ class BlockchainInfoServiceTest : TestBase() {
             assertThrows<ResourceNotFoundException>(message) {
                 service.fetchErc20AccountBalanceFromSignedMessage(
                     messageId = UUID.randomUUID(),
-                    chainId = Chain.HARDHAT_TESTNET.id,
+                    chainSpec = Chain.HARDHAT_TESTNET.id.toSpec(),
                     contractAddress = ContractAddress("a")
                 )
             }
         }
     }
+
+    private fun ChainId.toSpec() = ChainSpec(this, null)
 }


### PR DESCRIPTION
Adds support to specify arbitrary `chainId` and `rpcUrl` for blockchain fetch requests.