### PR TITLE
SD-751: make predetermined chain RPC urls non-overridable

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -2,7 +2,7 @@ import org.gradle.api.JavaVersion
 
 object Versions {
 
-    const val project = "0.1.0"
+    const val project = "0.1.1"
 
     object Compile {
         const val kotlin = "1.6.10"

--- a/src/apiTest/kotlin/com/ampnet/blockchainapiservice/controller/BlockchainInfoControllerApiTest.kt
+++ b/src/apiTest/kotlin/com/ampnet/blockchainapiservice/controller/BlockchainInfoControllerApiTest.kt
@@ -3,7 +3,7 @@ package com.ampnet.blockchainapiservice.controller
 import com.ampnet.blockchainapiservice.ControllerTestBase
 import com.ampnet.blockchainapiservice.TestData
 import com.ampnet.blockchainapiservice.blockchain.SimpleERC20
-import com.ampnet.blockchainapiservice.config.binding.ChainSpecResolver
+import com.ampnet.blockchainapiservice.config.binding.RpcUrlSpecResolver
 import com.ampnet.blockchainapiservice.exception.ErrorCode
 import com.ampnet.blockchainapiservice.generated.jooq.tables.SignedVerificationMessageTable
 import com.ampnet.blockchainapiservice.model.response.FetchErc20TokenBalanceResponse
@@ -132,7 +132,10 @@ class BlockchainInfoControllerApiTest : ControllerTestBase() {
                     "/info/123456/${TestData.SIGNED_MESSAGE.id}/erc20-balance/${contractAddress.rawValue}"
                 )
                     .queryParam("blockNumber", blockNumber.value.toString())
-                    .header(ChainSpecResolver.RPC_URL_HEADER, "http://localhost:${hardhatContainer.mappedPort}")
+                    .header(
+                        RpcUrlSpecResolver.RPC_URL_OVERRIDE_HEADER,
+                        "http://localhost:${hardhatContainer.mappedPort}"
+                    )
             )
                 .andExpect(MockMvcResultMatchers.status().isOk)
                 .andReturn()

--- a/src/apiTest/kotlin/com/ampnet/blockchainapiservice/controller/SendErc20RequestControllerApiTest.kt
+++ b/src/apiTest/kotlin/com/ampnet/blockchainapiservice/controller/SendErc20RequestControllerApiTest.kt
@@ -3,7 +3,7 @@ package com.ampnet.blockchainapiservice.controller
 import com.ampnet.blockchainapiservice.ControllerTestBase
 import com.ampnet.blockchainapiservice.blockchain.SimpleERC20
 import com.ampnet.blockchainapiservice.blockchain.properties.Chain
-import com.ampnet.blockchainapiservice.config.binding.ChainSpecResolver
+import com.ampnet.blockchainapiservice.config.binding.RpcUrlSpecResolver
 import com.ampnet.blockchainapiservice.exception.ErrorCode
 import com.ampnet.blockchainapiservice.generated.jooq.tables.ClientInfoTable
 import com.ampnet.blockchainapiservice.generated.jooq.tables.SendErc20RequestTable
@@ -551,7 +551,10 @@ class SendErc20RequestControllerApiTest : ControllerTestBase() {
         val fetchResponse = suppose("request to fetch send ERC20 request is made") {
             val fetchResponse = mockMvc.perform(
                 MockMvcRequestBuilders.get("/send/${createResponse.id}")
-                    .header(ChainSpecResolver.RPC_URL_HEADER, "http://localhost:${hardhatContainer.mappedPort}")
+                    .header(
+                        RpcUrlSpecResolver.RPC_URL_OVERRIDE_HEADER,
+                        "http://localhost:${hardhatContainer.mappedPort}"
+                    )
             )
                 .andExpect(MockMvcResultMatchers.status().isOk)
                 .andReturn()

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -35,7 +35,8 @@ include::{snippets}/VerificationControllerApiTest/mustCorrectlyVerifyValidMessag
 
 == Blockchain Into API
 All endpoints are public and do not require `Authorization: Bearer JWT` header. Custom RPC URL can be specified via
-optional `X-RPC-URL` header - this will override the default RPC URL for the specified chain ID.
+optional `X-RPC-URL` header - this will NOT override the default RPC URL for the specified chain ID, it only allows you
+to specify RPC URL for non-natively supported chains. To override the default RPC URL, use `X-RPC-URL-OVERRIDE` header.
 
 === Fetch ERC20 balance for verified account
 Fetches ERC20 balance of specified contract address for the account which signed verification message with given ID.
@@ -77,8 +78,9 @@ any mismatches between specified request data and state on blockchain, the reque
 no attached transaction hash or if transaction for attached hash is not yet mined on blockchain, request will be in
 pending state.
 
-Custom RPC URL can be specified via optional `X-RPC-URL` header - this will override the default RPC URL for the
-specified chain ID.
+Custom RPC URL can be specified via optional `X-RPC-URL` header - this will NOT override the default RPC URL for the
+specified chain ID, it only allows you to specify RPC URL for non-natively supported chains. To override the default RPC
+URL, use `X-RPC-URL-OVERRIDE` header.
 
 .Request
 include::{snippets}/SendErc20RequestControllerApiTest/mustCorrectlyFetchSendErc20Request/http-request.adoc[]

--- a/src/integTest/kotlin/com/ampnet/blockchainapiservice/blockchain/Web3jBlockchainServiceIntegTest.kt
+++ b/src/integTest/kotlin/com/ampnet/blockchainapiservice/blockchain/Web3jBlockchainServiceIntegTest.kt
@@ -3,6 +3,7 @@ package com.ampnet.blockchainapiservice.blockchain
 import com.ampnet.blockchainapiservice.TestBase
 import com.ampnet.blockchainapiservice.blockchain.properties.Chain
 import com.ampnet.blockchainapiservice.blockchain.properties.ChainSpec
+import com.ampnet.blockchainapiservice.blockchain.properties.RpcUrlSpec
 import com.ampnet.blockchainapiservice.config.ApplicationProperties
 import com.ampnet.blockchainapiservice.exception.BlockchainReadException
 import com.ampnet.blockchainapiservice.model.result.BlockchainTransactionInfo
@@ -270,5 +271,5 @@ class Web3jBlockchainServiceIntegTest : TestBase() {
 
     private fun hardhatProperties() = ApplicationProperties().apply { infuraId = hardhatContainer.mappedPort }
 
-    private fun ChainId.toSpec() = ChainSpec(this, null)
+    private fun ChainId.toSpec() = ChainSpec(this, RpcUrlSpec(null, null))
 }

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/blockchain/properties/ChainSpec.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/blockchain/properties/ChainSpec.kt
@@ -2,4 +2,12 @@ package com.ampnet.blockchainapiservice.blockchain.properties
 
 import com.ampnet.blockchainapiservice.util.ChainId
 
-data class ChainSpec(val chainId: ChainId, val rpcUrl: String?)
+data class ChainSpec(
+    val chainId: ChainId,
+    val rpcSpec: RpcUrlSpec
+)
+
+data class RpcUrlSpec(
+    val url: String?,
+    val urlOverride: String?
+)

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/config/WebConfig.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/config/WebConfig.kt
@@ -1,6 +1,7 @@
 package com.ampnet.blockchainapiservice.config
 
 import com.ampnet.blockchainapiservice.config.binding.ChainSpecResolver
+import com.ampnet.blockchainapiservice.config.binding.RpcUrlSpecResolver
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
@@ -8,6 +9,9 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 @Configuration
 class WebConfig : WebMvcConfigurer {
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
-        resolvers.add(ChainSpecResolver())
+        val rpcUrlSpecResolver = RpcUrlSpecResolver()
+
+        resolvers.add(rpcUrlSpecResolver)
+        resolvers.add(ChainSpecResolver(rpcUrlSpecResolver))
     }
 }

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/config/binding/ChainSpecResolver.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/config/binding/ChainSpecResolver.kt
@@ -11,11 +11,7 @@ import org.springframework.web.method.support.ModelAndViewContainer
 import org.springframework.web.servlet.HandlerMapping
 import javax.servlet.http.HttpServletRequest
 
-class ChainSpecResolver : HandlerMethodArgumentResolver {
-
-    companion object {
-        const val RPC_URL_HEADER = "X-RPC-URL"
-    }
+class ChainSpecResolver(private val rpcUrlSpecResolver: RpcUrlSpecResolver) : HandlerMethodArgumentResolver {
 
     override fun supportsParameter(parameter: MethodParameter): Boolean {
         return parameter.parameterType == ChainSpec::class.java &&
@@ -41,9 +37,8 @@ class ChainSpecResolver : HandlerMethodArgumentResolver {
             ?: throw IllegalStateException(
                 "Path variable \"$chainIdPathVariable\" is missing from the controller specification."
             )
-        // RPC URL is an optional header
-        val rpcUrl = httpServletRequest.getHeader(RPC_URL_HEADER)
+        val rpcUrlSpec = rpcUrlSpecResolver.resolveArgument(parameter, mavContainer, nativeWebRequest, binderFactory)
 
-        return ChainSpec(chainId, rpcUrl)
+        return ChainSpec(chainId, rpcUrlSpec)
     }
 }

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/config/binding/RpcUrlSpecResolver.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/config/binding/RpcUrlSpecResolver.kt
@@ -1,0 +1,37 @@
+package com.ampnet.blockchainapiservice.config.binding
+
+import com.ampnet.blockchainapiservice.blockchain.properties.RpcUrlSpec
+import com.ampnet.blockchainapiservice.config.binding.annotation.RpcUrlBinding
+import org.springframework.core.MethodParameter
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+import javax.servlet.http.HttpServletRequest
+
+class RpcUrlSpecResolver : HandlerMethodArgumentResolver {
+
+    companion object {
+        const val RPC_URL_HEADER = "X-RPC-URL"
+        const val RPC_URL_OVERRIDE_HEADER = "X-RPC-URL-OVERRIDE"
+    }
+
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        return parameter.parameterType == RpcUrlSpec::class.java &&
+            parameter.hasParameterAnnotation(RpcUrlBinding::class.java)
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        nativeWebRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?
+    ): RpcUrlSpec {
+        val httpServletRequest = nativeWebRequest.getNativeRequest(HttpServletRequest::class.java)
+        // RPC URL is an optional header
+        val rpcUrl = httpServletRequest?.getHeader(RPC_URL_HEADER)
+        val rpcUrlOverride = httpServletRequest?.getHeader(RPC_URL_OVERRIDE_HEADER)
+
+        return RpcUrlSpec(rpcUrl, rpcUrlOverride)
+    }
+}

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/config/binding/annotation/RpcUrlBinding.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/config/binding/annotation/RpcUrlBinding.kt
@@ -1,0 +1,5 @@
+package com.ampnet.blockchainapiservice.config.binding.annotation
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.VALUE_PARAMETER)
+annotation class RpcUrlBinding

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/controller/SendErc20RequestController.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/controller/SendErc20RequestController.kt
@@ -1,6 +1,7 @@
 package com.ampnet.blockchainapiservice.controller
 
-import com.ampnet.blockchainapiservice.config.binding.ChainSpecResolver
+import com.ampnet.blockchainapiservice.blockchain.properties.RpcUrlSpec
+import com.ampnet.blockchainapiservice.config.binding.annotation.RpcUrlBinding
 import com.ampnet.blockchainapiservice.model.SendScreenConfig
 import com.ampnet.blockchainapiservice.model.params.CreateSendErc20RequestParams
 import com.ampnet.blockchainapiservice.model.request.AttachTransactionHashRequest
@@ -20,7 +21,6 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
@@ -71,9 +71,9 @@ class SendErc20RequestController(private val sendErc20RequestService: SendErc20R
     @GetMapping("/send/{id}")
     fun getSendErc20Request(
         @PathVariable("id") id: UUID,
-        @RequestHeader(name = ChainSpecResolver.RPC_URL_HEADER, required = false) rpcUrl: String?
+        @RpcUrlBinding rpcSpec: RpcUrlSpec
     ): ResponseEntity<SendErc20RequestResponse> {
-        val sendRequest = sendErc20RequestService.getSendErc20Request(id, rpcUrl)
+        val sendRequest = sendErc20RequestService.getSendErc20Request(id, rpcSpec)
 
         return ResponseEntity.ok(
             SendErc20RequestResponse(

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/service/SendErc20RequestService.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/service/SendErc20RequestService.kt
@@ -1,5 +1,6 @@
 package com.ampnet.blockchainapiservice.service
 
+import com.ampnet.blockchainapiservice.blockchain.properties.RpcUrlSpec
 import com.ampnet.blockchainapiservice.model.params.CreateSendErc20RequestParams
 import com.ampnet.blockchainapiservice.model.result.FullSendErc20Request
 import com.ampnet.blockchainapiservice.model.result.SendErc20Request
@@ -9,6 +10,6 @@ import java.util.UUID
 
 interface SendErc20RequestService {
     fun createSendErc20Request(params: CreateSendErc20RequestParams): WithFunctionData<SendErc20Request>
-    fun getSendErc20Request(id: UUID, rpcUrl: String?): FullSendErc20Request
+    fun getSendErc20Request(id: UUID, rpcSpec: RpcUrlSpec): FullSendErc20Request
     fun attachTxHash(id: UUID, txHash: TransactionHash)
 }

--- a/src/main/kotlin/com/ampnet/blockchainapiservice/service/SendErc20RequestServiceImpl.kt
+++ b/src/main/kotlin/com/ampnet/blockchainapiservice/service/SendErc20RequestServiceImpl.kt
@@ -2,6 +2,7 @@ package com.ampnet.blockchainapiservice.service
 
 import com.ampnet.blockchainapiservice.blockchain.BlockchainService
 import com.ampnet.blockchainapiservice.blockchain.properties.ChainSpec
+import com.ampnet.blockchainapiservice.blockchain.properties.RpcUrlSpec
 import com.ampnet.blockchainapiservice.config.ApplicationProperties
 import com.ampnet.blockchainapiservice.exception.CannotAttachTxHashException
 import com.ampnet.blockchainapiservice.exception.IncompleteSendErc20RequestException
@@ -59,7 +60,7 @@ class SendErc20RequestServiceImpl(
         )
     }
 
-    override fun getSendErc20Request(id: UUID, rpcUrl: String?): FullSendErc20Request {
+    override fun getSendErc20Request(id: UUID, rpcSpec: RpcUrlSpec): FullSendErc20Request {
         logger.debug { "Fetching send ERC20 request, id: $id" }
 
         val sendErc20Request = sendErc20RequestRepository.getById(id)
@@ -69,7 +70,7 @@ class SendErc20RequestServiceImpl(
             blockchainService.fetchTransactionInfo(
                 chainSpec = ChainSpec(
                     chainId = sendErc20Request.chainId,
-                    rpcUrl = rpcUrl
+                    rpcSpec = rpcSpec
                 ),
                 txHash = sendErc20Request.transactionData.txHash
             )

--- a/src/test/kotlin/com/ampnet/blockchainapiservice/blockchain/ChainPropertiesHandlerTest.kt
+++ b/src/test/kotlin/com/ampnet/blockchainapiservice/blockchain/ChainPropertiesHandlerTest.kt
@@ -4,6 +4,7 @@ import com.ampnet.blockchainapiservice.TestBase
 import com.ampnet.blockchainapiservice.blockchain.properties.Chain
 import com.ampnet.blockchainapiservice.blockchain.properties.ChainPropertiesHandler
 import com.ampnet.blockchainapiservice.blockchain.properties.ChainSpec
+import com.ampnet.blockchainapiservice.blockchain.properties.RpcUrlSpec
 import com.ampnet.blockchainapiservice.config.ApplicationProperties
 import com.ampnet.blockchainapiservice.exception.ErrorCode
 import com.ampnet.blockchainapiservice.exception.UnsupportedChainIdException
@@ -36,7 +37,24 @@ class ChainPropertiesHandlerTest : TestBase() {
             val chainProperties = chainPropertiesHandler.getBlockchainProperties(
                 ChainSpec(
                     chainId = ChainId(123L),
-                    rpcUrl = "http://localhost:1234/"
+                    rpcSpec = RpcUrlSpec(url = "http://localhost:1234/", urlOverride = null)
+                )
+            )
+            assertThat(chainProperties.web3j).withMessage().isNotNull()
+        }
+    }
+
+    @Test
+    fun mustCorrectlyCreateChainPropertiesWithServicesWhenRpcUrlOverrideIsSpecified() {
+        val chainPropertiesHandler = suppose("chain properties handler is created from application properties") {
+            ChainPropertiesHandler(ApplicationProperties().apply { infuraId = "" })
+        }
+
+        verify("chain properties with services are correctly created") {
+            val chainProperties = chainPropertiesHandler.getBlockchainProperties(
+                ChainSpec(
+                    chainId = ChainId(123L),
+                    rpcSpec = RpcUrlSpec(url = null, urlOverride = "http://localhost:1234/")
                 )
             )
             assertThat(chainProperties.web3j).withMessage().isNotNull()
@@ -101,5 +119,5 @@ class ChainPropertiesHandlerTest : TestBase() {
         }
     }
 
-    private fun ChainId.toSpec() = ChainSpec(this, null)
+    private fun ChainId.toSpec() = ChainSpec(this, RpcUrlSpec(null, null))
 }

--- a/src/test/kotlin/com/ampnet/blockchainapiservice/controller/BlockchainInfoControllerTest.kt
+++ b/src/test/kotlin/com/ampnet/blockchainapiservice/controller/BlockchainInfoControllerTest.kt
@@ -3,6 +3,7 @@ package com.ampnet.blockchainapiservice.controller
 import com.ampnet.blockchainapiservice.TestBase
 import com.ampnet.blockchainapiservice.blockchain.properties.Chain
 import com.ampnet.blockchainapiservice.blockchain.properties.ChainSpec
+import com.ampnet.blockchainapiservice.blockchain.properties.RpcUrlSpec
 import com.ampnet.blockchainapiservice.model.response.FetchErc20TokenBalanceResponse
 import com.ampnet.blockchainapiservice.service.BlockchainInfoService
 import com.ampnet.blockchainapiservice.util.AccountBalance
@@ -111,5 +112,5 @@ class BlockchainInfoControllerTest : TestBase() {
         }
     }
 
-    private fun ChainId.toSpec() = ChainSpec(this, null)
+    private fun ChainId.toSpec() = ChainSpec(this, RpcUrlSpec(null, null))
 }

--- a/src/test/kotlin/com/ampnet/blockchainapiservice/controller/SendErc20RequestControllerTest.kt
+++ b/src/test/kotlin/com/ampnet/blockchainapiservice/controller/SendErc20RequestControllerTest.kt
@@ -1,6 +1,7 @@
 package com.ampnet.blockchainapiservice.controller
 
 import com.ampnet.blockchainapiservice.TestBase
+import com.ampnet.blockchainapiservice.blockchain.properties.RpcUrlSpec
 import com.ampnet.blockchainapiservice.model.SendScreenConfig
 import com.ampnet.blockchainapiservice.model.params.CreateSendErc20RequestParams
 import com.ampnet.blockchainapiservice.model.request.AttachTransactionHashRequest
@@ -118,7 +119,7 @@ class SendErc20RequestControllerTest : TestBase() {
     @Test
     fun mustCorrectlyFetchSendErc20Request() {
         val id = UUID.randomUUID()
-        val rpcUrl = "rpc-url"
+        val rpcSpec = RpcUrlSpec("url", "url-override")
         val service = mock<SendErc20RequestService>()
         val result = FullSendErc20Request(
             id = id,
@@ -143,14 +144,14 @@ class SendErc20RequestControllerTest : TestBase() {
         )
 
         suppose("some send ERC20 request will be fetched") {
-            given(service.getSendErc20Request(id, rpcUrl))
+            given(service.getSendErc20Request(id, rpcSpec))
                 .willReturn(result)
         }
 
         val controller = SendErc20RequestController(service)
 
         verify("controller returns correct response") {
-            assertThat(controller.getSendErc20Request(id, rpcUrl)).withMessage()
+            assertThat(controller.getSendErc20Request(id, rpcSpec)).withMessage()
                 .isEqualTo(
                     ResponseEntity.ok(
                         SendErc20RequestResponse(

--- a/src/test/kotlin/com/ampnet/blockchainapiservice/service/BlockchainInfoServiceTest.kt
+++ b/src/test/kotlin/com/ampnet/blockchainapiservice/service/BlockchainInfoServiceTest.kt
@@ -5,6 +5,7 @@ import com.ampnet.blockchainapiservice.TestData
 import com.ampnet.blockchainapiservice.blockchain.BlockchainService
 import com.ampnet.blockchainapiservice.blockchain.properties.Chain
 import com.ampnet.blockchainapiservice.blockchain.properties.ChainSpec
+import com.ampnet.blockchainapiservice.blockchain.properties.RpcUrlSpec
 import com.ampnet.blockchainapiservice.exception.ExpiredValidationMessageException
 import com.ampnet.blockchainapiservice.exception.ResourceNotFoundException
 import com.ampnet.blockchainapiservice.repository.SignedVerificationMessageRepository
@@ -144,5 +145,5 @@ class BlockchainInfoServiceTest : TestBase() {
         }
     }
 
-    private fun ChainId.toSpec() = ChainSpec(this, null)
+    private fun ChainId.toSpec() = ChainSpec(this, RpcUrlSpec(null, null))
 }

--- a/src/test/kotlin/com/ampnet/blockchainapiservice/service/SendErc20RequestServiceTest.kt
+++ b/src/test/kotlin/com/ampnet/blockchainapiservice/service/SendErc20RequestServiceTest.kt
@@ -4,6 +4,7 @@ import com.ampnet.blockchainapiservice.TestBase
 import com.ampnet.blockchainapiservice.blockchain.BlockchainService
 import com.ampnet.blockchainapiservice.blockchain.properties.Chain
 import com.ampnet.blockchainapiservice.blockchain.properties.ChainSpec
+import com.ampnet.blockchainapiservice.blockchain.properties.RpcUrlSpec
 import com.ampnet.blockchainapiservice.config.ApplicationProperties
 import com.ampnet.blockchainapiservice.exception.CannotAttachTxHashException
 import com.ampnet.blockchainapiservice.exception.IncompleteSendErc20RequestException
@@ -344,7 +345,7 @@ class SendErc20RequestServiceTest : TestBase() {
 
         verify("ResourceNotFoundException is thrown") {
             assertThrows<ResourceNotFoundException>(message) {
-                service.getSendErc20Request(id = UUID.randomUUID(), rpcUrl = null)
+                service.getSendErc20Request(id = UUID.randomUUID(), rpcSpec = RpcUrlSpec(null, null))
             }
         }
     }
@@ -406,7 +407,7 @@ class SendErc20RequestServiceTest : TestBase() {
         )
 
         verify("send ERC20 request with pending status is returned") {
-            assertThat(service.getSendErc20Request(id = id, rpcUrl = null)).withMessage()
+            assertThat(service.getSendErc20Request(id = id, rpcSpec = RpcUrlSpec(null, null))).withMessage()
                 .isEqualTo(
                     FullSendErc20Request.fromSendErc20Request(
                         request = sendRequest,
@@ -448,7 +449,7 @@ class SendErc20RequestServiceTest : TestBase() {
         }
 
         val blockchainService = mock<BlockchainService>()
-        val chainSpec = ChainSpec(sendRequest.chainId, "rpc-url")
+        val chainSpec = ChainSpec(sendRequest.chainId, RpcUrlSpec("url", "url-override"))
 
         suppose("transaction is not yet mined") {
             given(blockchainService.fetchTransactionInfo(chainSpec, TX_HASH))
@@ -484,7 +485,7 @@ class SendErc20RequestServiceTest : TestBase() {
         )
 
         verify("send ERC20 request with pending status is returned") {
-            assertThat(service.getSendErc20Request(id = id, rpcUrl = chainSpec.rpcUrl)).withMessage()
+            assertThat(service.getSendErc20Request(id = id, rpcSpec = chainSpec.rpcSpec)).withMessage()
                 .isEqualTo(
                     FullSendErc20Request.fromSendErc20Request(
                         request = sendRequest,
@@ -526,7 +527,7 @@ class SendErc20RequestServiceTest : TestBase() {
         }
 
         val blockchainService = mock<BlockchainService>()
-        val chainSpec = ChainSpec(sendRequest.chainId, "rpc-url")
+        val chainSpec = ChainSpec(sendRequest.chainId, RpcUrlSpec("url", "url-override"))
         val encodedData = FunctionData("encoded")
         val transactionInfo = BlockchainTransactionInfo(
             hash = TX_HASH,
@@ -569,7 +570,7 @@ class SendErc20RequestServiceTest : TestBase() {
         )
 
         verify("send ERC20 request with failed status is returned") {
-            assertThat(service.getSendErc20Request(id = id, rpcUrl = chainSpec.rpcUrl)).withMessage()
+            assertThat(service.getSendErc20Request(id = id, rpcSpec = chainSpec.rpcSpec)).withMessage()
                 .isEqualTo(
                     FullSendErc20Request.fromSendErc20Request(
                         request = sendRequest,
@@ -611,7 +612,7 @@ class SendErc20RequestServiceTest : TestBase() {
         }
 
         val blockchainService = mock<BlockchainService>()
-        val chainSpec = ChainSpec(sendRequest.chainId, "rpc-url")
+        val chainSpec = ChainSpec(sendRequest.chainId, RpcUrlSpec("url", "url-override"))
         val encodedData = FunctionData("encoded")
         val transactionInfo = BlockchainTransactionInfo(
             hash = TransactionHash("wrong-hash"),
@@ -654,7 +655,7 @@ class SendErc20RequestServiceTest : TestBase() {
         )
 
         verify("send ERC20 request with failed status is returned") {
-            assertThat(service.getSendErc20Request(id = id, rpcUrl = chainSpec.rpcUrl)).withMessage()
+            assertThat(service.getSendErc20Request(id = id, rpcSpec = chainSpec.rpcSpec)).withMessage()
                 .isEqualTo(
                     FullSendErc20Request.fromSendErc20Request(
                         request = sendRequest,
@@ -696,7 +697,7 @@ class SendErc20RequestServiceTest : TestBase() {
         }
 
         val blockchainService = mock<BlockchainService>()
-        val chainSpec = ChainSpec(sendRequest.chainId, "rpc-url")
+        val chainSpec = ChainSpec(sendRequest.chainId, RpcUrlSpec("url", "url-override"))
         val encodedData = FunctionData("encoded")
         val transactionInfo = BlockchainTransactionInfo(
             hash = TX_HASH,
@@ -739,7 +740,7 @@ class SendErc20RequestServiceTest : TestBase() {
         )
 
         verify("send ERC20 request with failed status is returned") {
-            assertThat(service.getSendErc20Request(id = id, rpcUrl = chainSpec.rpcUrl)).withMessage()
+            assertThat(service.getSendErc20Request(id = id, rpcSpec = chainSpec.rpcSpec)).withMessage()
                 .isEqualTo(
                     FullSendErc20Request.fromSendErc20Request(
                         request = sendRequest,
@@ -781,7 +782,7 @@ class SendErc20RequestServiceTest : TestBase() {
         }
 
         val blockchainService = mock<BlockchainService>()
-        val chainSpec = ChainSpec(sendRequest.chainId, "rpc-url")
+        val chainSpec = ChainSpec(sendRequest.chainId, RpcUrlSpec("url", "url-override"))
         val encodedData = FunctionData("encoded")
         val transactionInfo = BlockchainTransactionInfo(
             hash = TX_HASH,
@@ -824,7 +825,7 @@ class SendErc20RequestServiceTest : TestBase() {
         )
 
         verify("send ERC20 request with failed status is returned") {
-            assertThat(service.getSendErc20Request(id = id, rpcUrl = chainSpec.rpcUrl)).withMessage()
+            assertThat(service.getSendErc20Request(id = id, rpcSpec = chainSpec.rpcSpec)).withMessage()
                 .isEqualTo(
                     FullSendErc20Request.fromSendErc20Request(
                         request = sendRequest,
@@ -866,7 +867,7 @@ class SendErc20RequestServiceTest : TestBase() {
         }
 
         val blockchainService = mock<BlockchainService>()
-        val chainSpec = ChainSpec(sendRequest.chainId, "rpc-url")
+        val chainSpec = ChainSpec(sendRequest.chainId, RpcUrlSpec("url", "url-override"))
         val encodedData = FunctionData("encoded")
         val transactionInfo = BlockchainTransactionInfo(
             hash = TX_HASH,
@@ -909,7 +910,7 @@ class SendErc20RequestServiceTest : TestBase() {
         )
 
         verify("send ERC20 request with successful status is returned") {
-            assertThat(service.getSendErc20Request(id = id, rpcUrl = chainSpec.rpcUrl)).withMessage()
+            assertThat(service.getSendErc20Request(id = id, rpcSpec = chainSpec.rpcSpec)).withMessage()
                 .isEqualTo(
                     FullSendErc20Request.fromSendErc20Request(
                         request = sendRequest,
@@ -951,7 +952,7 @@ class SendErc20RequestServiceTest : TestBase() {
         }
 
         val blockchainService = mock<BlockchainService>()
-        val chainSpec = ChainSpec(sendRequest.chainId, "rpc-url")
+        val chainSpec = ChainSpec(sendRequest.chainId, RpcUrlSpec("url", "url-override"))
         val encodedData = FunctionData("encoded")
         val transactionInfo = BlockchainTransactionInfo(
             hash = TX_HASH,
@@ -994,7 +995,7 @@ class SendErc20RequestServiceTest : TestBase() {
         )
 
         verify("send ERC20 request with successful status is returned") {
-            assertThat(service.getSendErc20Request(id = id, rpcUrl = chainSpec.rpcUrl)).withMessage()
+            assertThat(service.getSendErc20Request(id = id, rpcSpec = chainSpec.rpcSpec)).withMessage()
                 .isEqualTo(
                     FullSendErc20Request.fromSendErc20Request(
                         request = sendRequest,


### PR DESCRIPTION
Makes default RPC URLs non-overridable by default, but still allows explicit overriding when so desired.